### PR TITLE
Remove unnecessary dotenv calls

### DIFF
--- a/src/utils/AlertsUtils.js
+++ b/src/utils/AlertsUtils.js
@@ -1,10 +1,9 @@
 // @flow
-import interval from 'interval-promise';
 import RequestUtils from './RequestUtils';
 import TokenUtils from './TokenUtils';
 import ErrorUtils from './LogUtils';
 
-let alerts = RequestUtils.fetchRetry(fetchAlerts);
+const alerts = RequestUtils.fetchRetry(fetchAlerts);
 const ONE_SEC_MS = 1000;
 const ONE_MINUTE_MS = ONE_SEC_MS * 60;
 

--- a/src/utils/GTFSUtils.js
+++ b/src/utils/GTFSUtils.js
@@ -1,14 +1,10 @@
-/* eslint-disable no-console */
 // @flow
 import csv from 'csvtojson';
-import dotenv from 'dotenv';
 import request from 'request';
 import fs from 'fs';
 import DecompressZip from 'decompress-zip';
 import moment from 'moment';
 import ErrorUtils from './LogUtils';
-
-dotenv.config();
 
 const root = '.';
 const zipFile = 'tcat-ny-us.zip';

--- a/src/utils/LogUtils.js
+++ b/src/utils/LogUtils.js
@@ -1,12 +1,10 @@
-/* eslint-disable no-console */
-import dotenv from 'dotenv';
+// @flow
 import fs from 'fs';
 import util from 'util';
 import { ParquetSchema } from 'parquetjs';
 import ChronicleSession from '../appdev/ChronicleSession';
 import Schemas from './Schemas';
 
-dotenv.load();
 const CHRONICLE_PROD_ENV = 'production';
 const CHRONICLE_DEV_ENV = 'development';
 const CHRONICLE_APP_NAME = 'IthacaTransit';

--- a/src/utils/TokenUtils.js
+++ b/src/utils/TokenUtils.js
@@ -1,11 +1,8 @@
 // @flow
 import fs from 'fs';
 import request from 'request';
-import dotenv from 'dotenv';
 import ErrorUtils from './LogUtils';
 import RequestUtils from './RequestUtils';
-
-dotenv.load();
 
 let credentials = { basic_token: process.env.TOKEN || null, access_token: null, expiry_date: null };
 


### PR DESCRIPTION
There only needs to be one call to `dotenv.config()`, and it's done in `server.js`. All of the others are redundant. I verified that this doesn't break anything.