### PR TITLE
Add timeout on server init to bypass availtec being down

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,19 +1,21 @@
 // @flow
 import dotenv from 'dotenv';
+import util from 'util';
 
 import API from './Api';
 import AlertsUtils from './utils/AlertsUtils';
 import AllStopUtils from './utils/AllStopUtils';
 import GhopperUtils from './utils/GraphhopperUtils';
-import ErrorUtils from './utils/LogUtils';
+import LogUtils from './utils/LogUtils';
 import RealtimeFeedUtils from './utils/RealtimeFeedUtils';
 import TokenUtils from './utils/TokenUtils';
 
 dotenv.config(); // dotenv needs to be configured before token fetch
-console.log('\x1b[36m%s\x1b[0m', 'Initializing data and waiting for Graphhopper services...');
+LogUtils.log({ message: 'server.js: Initializing data and waiting for Graphhopper services...' });
 
 const PORT: number = parseInt(process.env.PORT) || 80;
 const SERVER_ADDRESS: string = '0.0.0.0';
+const TWENTY_SECONDS_IN_MS: number = 20000;
 
 const authToken = TokenUtils.fetchAuthHeader();
 
@@ -26,13 +28,17 @@ const init = new Promise((resolve, reject) => {
     // start endpoints that rely on external data starting with authentication token
     authToken.then(() => {
         // await data
-        const dataInit = Promise.all([
-            RealtimeFeedUtils.realtimeFeed,
-            AllStopUtils.allStops,
-            AlertsUtils.alerts,
-            TokenUtils.fetchAuthHeader(),
+        const dataInit = Promise.race([
+            Promise.all([
+                RealtimeFeedUtils.realtimeFeed,
+                AllStopUtils.allStops,
+                AlertsUtils.alerts,
+                TokenUtils.fetchAuthHeader(),
+            ]),
+            (util.promisify(setTimeout))(TWENTY_SECONDS_IN_MS)
+                .then(() => LogUtils.log({ message: 'server.js: Timeout reached' })),
         ]).then(() => {
-            console.log('Initialized data successfully: authHeader, realtimeFeed, allStops, alerts');
+            LogUtils.log({ message: 'server.js: Initialized data successfully' });
         });
 
         // await full initialization then listen on the port
@@ -41,15 +47,16 @@ const init = new Promise((resolve, reject) => {
             GhopperUtils.isGraphhopperReady,
         ]).then(() => {
             server.listen(PORT, SERVER_ADDRESS, () => {
-                console.log('\x1b[36m%s\x1b[0m',
-                    'Initialized Graphhopper and all data successfully!\n'
-                                + `Transit Backend listening on ${SERVER_ADDRESS}:${PORT}`);
+                LogUtils.log({
+                    message: 'server.js: Initialized Graphhopper and all data successfully!\n'
+                    + `Transit Backend listening on ${SERVER_ADDRESS}:${PORT}`,
+                });
                 resolve(PORT);
             });
         });
     });
 }).then(value => value).catch((error) => {
-    ErrorUtils.logErr(error, null, 'Transit init failed');
+    LogUtils.logErr(error, null, 'Transit init failed');
     return null;
 });
 


### PR DESCRIPTION
In the picture below, we can see that the server never fully initialized while availtec was down (between 9AM-12PM)

<img width="908" alt="screen shot 2019-01-25 at 1 47 54 pm" src="https://user-images.githubusercontent.com/8889311/51766234-1165f580-20a8-11e9-83bd-5160d8d2bd1a.png">

I added a `Promise.race` to ensure that no matter what happens, the server will advance to the next step after 20 seconds. 