### PR TITLE
Deprecate fetch of stops & alerts #145

### DIFF
--- a/env.template
+++ b/env.template
@@ -1,11 +1,9 @@
-ALERTS=localhost
-ALL_STOPS=localhost
 GHOPPER_BUS=localhost
 GHOPPER_WALKING=localhost
-LIVE_TRACKING=localhost
 MAP_MATCHING=localhost
 NODE_ENV=production
 PLACES_KEY=PLACES_KEY
 PORT=3000
 RELEASE_URL=http://localhost:3001/
+TCAT_SERVICE=localhost
 TOKEN=token

--- a/env.template
+++ b/env.template
@@ -4,6 +4,6 @@ MAP_MATCHING=localhost
 NODE_ENV=production
 PLACES_KEY=PLACES_KEY
 PORT=3000
+PYTHON_APP=localhost
 RELEASE_URL=http://localhost:3001/
-TCAT_SERVICE=localhost
 TOKEN=token

--- a/env.template
+++ b/env.template
@@ -1,3 +1,5 @@
+ALERTS=localhost
+ALL_STOPS=localhost
 GHOPPER_BUS=localhost
 GHOPPER_WALKING=localhost
 LIVE_TRACKING=localhost

--- a/src/routers/AlertsRouter.js
+++ b/src/routers/AlertsRouter.js
@@ -13,7 +13,7 @@ class AlertsRouter extends ApplicationRouter<Array<Object>> {
 
     // eslint-disable-next-line require-await
     async content(req): Promise<any> {
-        return AlertsUtils.getAlerts();
+        return AlertsUtils.fetchAlerts();
     }
 }
 

--- a/src/routers/AlertsRouter.js
+++ b/src/routers/AlertsRouter.js
@@ -13,7 +13,7 @@ class AlertsRouter extends ApplicationRouter<Array<Object>> {
 
     // eslint-disable-next-line require-await
     async content(req): Promise<any> {
-        return AlertsUtils.alerts;
+        return AlertsUtils.getAlerts();
     }
 }
 

--- a/src/routers/AllStopsRouter.js
+++ b/src/routers/AllStopsRouter.js
@@ -13,7 +13,7 @@ class AllStopsRouter extends ApplicationRouter<Array<Object>> {
 
     // eslint-disable-next-line require-await
     async content(req): Promise<any> {
-        return AllStopUtils.getAllStops();
+        return AllStopUtils.fetchAllStops();
     }
 }
 

--- a/src/routers/AllStopsRouter.js
+++ b/src/routers/AllStopsRouter.js
@@ -13,7 +13,7 @@ class AllStopsRouter extends ApplicationRouter<Array<Object>> {
 
     // eslint-disable-next-line require-await
     async content(req): Promise<any> {
-        return AllStopUtils.allStops;
+        return AllStopUtils.getAllStops();
     }
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -2,7 +2,6 @@
 import dotenv from 'dotenv';
 
 import API from './Api';
-import AlertsUtils from './utils/AlertsUtils';
 import AllStopUtils from './utils/AllStopUtils';
 import GhopperUtils from './utils/GraphhopperUtils';
 import LogUtils from './utils/LogUtils';
@@ -31,8 +30,6 @@ const init = new Promise((resolve, reject) => {
         // await data
         const dataInit = Promise.race([
             Promise.all([
-                AllStopUtils.allStops,
-                AlertsUtils.alerts,
                 TokenUtils.fetchAuthHeader(),
             ]),
             timeoutPromise,
@@ -48,7 +45,7 @@ const init = new Promise((resolve, reject) => {
             server.listen(PORT, SERVER_ADDRESS, () => {
                 LogUtils.log({
                     message: 'server.js: Initialized Graphhopper and all data successfully!\n'
-                    + `Transit Backend listening on ${SERVER_ADDRESS}:${PORT}`,
+                        + `Transit Backend listening on ${SERVER_ADDRESS}:${PORT}`,
                 });
                 resolve(PORT);
             });

--- a/src/server.js
+++ b/src/server.js
@@ -2,7 +2,6 @@
 import dotenv from 'dotenv';
 
 import API from './Api';
-import AllStopUtils from './utils/AllStopUtils';
 import GhopperUtils from './utils/GraphhopperUtils';
 import LogUtils from './utils/LogUtils';
 import TokenUtils from './utils/TokenUtils';
@@ -29,9 +28,7 @@ const init = new Promise((resolve, reject) => {
     authToken.then(() => {
         // await data
         const dataInit = Promise.race([
-            Promise.all([
-                TokenUtils.fetchAuthHeader(),
-            ]),
+            TokenUtils.fetchAuthHeader(),
             timeoutPromise,
         ]).then(() => {
             LogUtils.log({ message: 'server.js: Initialized data successfully' });

--- a/src/utils/AlertsUtils.js
+++ b/src/utils/AlertsUtils.js
@@ -1,94 +1,22 @@
 // @flow
+import { ALERTS } from './EnvUtils';
 import RequestUtils from './RequestUtils';
-import TokenUtils from './TokenUtils';
-import LogUtils from './LogUtils';
 
-const alerts = RequestUtils.fetchWithRetry(fetchAlerts);
-const ONE_SEC_MS = 1000;
-const ONE_MINUTE_MS = ONE_SEC_MS * 60;
-
-const updateAlertsFunction = async () => {
-    await RequestUtils.fetchWithRetry(fetchAlerts);
-    return true;
-};
-
-RequestUtils.updateObjectOnInterval(
-    updateAlertsFunction,
-    ONE_MINUTE_MS,
-    ONE_MINUTE_MS,
-    alerts,
-);
-
-async function fetchAlerts() {
-    try {
-        const authHeader = await TokenUtils.fetchAuthHeader();
-
-        const options = {
-            method: 'GET',
-            url: 'https://gateway.api.cloud.wso2.com:443/t/mystop/tcat/v1/rest/PublicMessages/GetAllMessages',
-            headers:
-                {
-                    'Cache-Control': 'no-cache',
-                    Authorization: authHeader,
-                },
-        };
-
-        const alertsRequest = await RequestUtils.createRequest(options, 'alerts request failed');
-
-        if (alertsRequest) {
-            return JSON.parse(alertsRequest).map(alert => ({
-                id: alert.MessageId,
-                message: alert.Message,
-                fromDate: convertUnixDateStrToJSDate(alert.FromDate),
-                toDate: convertUnixDateStrToJSDate(alert.ToDate),
-                fromTime: convertUnixDateStrToJSDate(alert.FromTime),
-                toTime: convertUnixDateStrToJSDate(alert.ToTime),
-                priority: alert.Priority,
-                daysOfWeek: convertTCATNumToStr(alert.DaysOfWeek),
-                routes: alert.Routes,
-                signs: alert.Signs,
-                channelMessages: alert.ChannelMessages,
-            }));
-        }
-    } catch (err) {
-        LogUtils.logErr(err, null, 'fetchAlerts error');
-        throw err;
-    }
-
-    return null;
+async function fetchAlerts(): Object {
+    const options = {
+        method: 'GET',
+        url: `http://${ALERTS || 'localhost'}:5000/alerts`,
+        headers: { 'Cache-Control': 'no-cache' },
+    };
+    const data = await RequestUtils.createRequest(options, 'Alerts request failed');
+    return JSON.parse(data);
 }
 
-function convertUnixDateStrToJSDate(dateStr: string): Date {
-    return new Date(parseInt(dateStr.substr(6)));
-}
-
-function convertTCATNumToStr(TCATNum: number) {
-    switch (TCATNum) {
-        case 127:
-            return 'Every day';
-        case 65:
-            return 'Weekends';
-        case 62:
-            return 'Weekdays';
-        case 2:
-            return 'Monday';
-        case 4:
-            return 'Tuesday';
-        case 8:
-            return 'Wednesday';
-        case 16:
-            return 'Thursday';
-        case 32:
-            return 'Friday';
-        case 64:
-            return 'Saturday';
-        case 1:
-            return 'Sunday';
-        default:
-            return '';
-    }
+async function getAlerts(): Object {
+    const alerts = await fetchAlerts();
+    return alerts;
 }
 
 export default {
-    alerts,
+    getAlerts,
 };

--- a/src/utils/AlertsUtils.js
+++ b/src/utils/AlertsUtils.js
@@ -1,11 +1,11 @@
 // @flow
-import { TCAT_SERVICE } from './EnvUtils';
+import { PYTHON_APP } from './EnvUtils';
 import RequestUtils from './RequestUtils';
 
 async function fetchAlerts(): Object {
     const options = {
         method: 'GET',
-        url: `http://${TCAT_SERVICE || 'localhost'}:5000/alerts`,
+        url: `http://${PYTHON_APP || 'localhost'}:5000/alerts`,
         headers: { 'Cache-Control': 'no-cache' },
     };
     const data = await RequestUtils.createRequest(options, 'Alerts request failed');

--- a/src/utils/AlertsUtils.js
+++ b/src/utils/AlertsUtils.js
@@ -1,11 +1,11 @@
 // @flow
-import { ALERTS } from './EnvUtils';
+import { TCAT_SERVICE } from './EnvUtils';
 import RequestUtils from './RequestUtils';
 
 async function fetchAlerts(): Object {
     const options = {
         method: 'GET',
-        url: `http://${ALERTS || 'localhost'}:5000/alerts`,
+        url: `http://${TCAT_SERVICE || 'localhost'}:5000/alerts`,
         headers: { 'Cache-Control': 'no-cache' },
     };
     const data = await RequestUtils.createRequest(options, 'Alerts request failed');

--- a/src/utils/AlertsUtils.js
+++ b/src/utils/AlertsUtils.js
@@ -12,11 +12,6 @@ async function fetchAlerts(): Object {
     return JSON.parse(data);
 }
 
-async function getAlerts(): Object {
-    const alerts = await fetchAlerts();
-    return alerts;
-}
-
 export default {
-    getAlerts,
+    fetchAlerts,
 };

--- a/src/utils/AllStopUtils.js
+++ b/src/utils/AllStopUtils.js
@@ -69,11 +69,6 @@ async function fetchAllStops() {
     return JSON.parse(data);
 }
 
-async function getAllStops() {
-    const allStops = await fetchAllStops();
-    return allStops;
-}
-
 function fetchPrecisionMaps() {
     const maps = {};
     maps[DEG_EQ_PRECISION] = getPrecisionMap(DEG_EQ_PRECISION);
@@ -90,7 +85,7 @@ async function getPrecisionMap(degreesPrecision: ?number = DEG_EQ_PRECISION) {
     if (degreesPrecision < 1 || degreesPrecision > 6) {
         return null;
     }
-    const stops = await allStops;
+    const stops = await fetchAllStops();
     if (allStopsCompareMaps && allStopsCompareMaps[degreesPrecision]) {
         return allStopsCompareMaps[degreesPrecision];
     }
@@ -146,7 +141,7 @@ export default {
     DEG_KM_PRECISION,
     DEG_NEARBY_PRECISION,
     DEG_WALK_PRECISION,
-    getAllStops,
+    fetchAllStops,
     isStop,
     isStopsWithinPrecision,
 };

--- a/src/utils/AllStopUtils.js
+++ b/src/utils/AllStopUtils.js
@@ -1,5 +1,5 @@
 // @flow
-import { ALL_STOPS } from './EnvUtils';
+import { TCAT_SERVICE } from './EnvUtils';
 import RequestUtils from './RequestUtils';
 
 const SEC_IN_MS = 1000;
@@ -62,7 +62,7 @@ RequestUtils.updateObjectOnInterval(
 async function fetchAllStops() {
     const options = {
         method: 'GET',
-        url: `http://${ALL_STOPS || 'localhost'}:5000/stops`,
+        url: `http://${TCAT_SERVICE || 'localhost'}:5000/stops`,
         headers: { 'Cache-Control': 'no-cache' },
     };
     const data = await RequestUtils.createRequest(options, 'AllStops request failed');

--- a/src/utils/AllStopUtils.js
+++ b/src/utils/AllStopUtils.js
@@ -1,5 +1,5 @@
 // @flow
-import { TCAT_SERVICE } from './EnvUtils';
+import { PYTHON_APP } from './EnvUtils';
 import RequestUtils from './RequestUtils';
 
 const SEC_IN_MS = 1000;
@@ -62,7 +62,7 @@ RequestUtils.updateObjectOnInterval(
 async function fetchAllStops() {
     const options = {
         method: 'GET',
-        url: `http://${TCAT_SERVICE || 'localhost'}:5000/stops`,
+        url: `http://${PYTHON_APP || 'localhost'}:5000/stops`,
         headers: { 'Cache-Control': 'no-cache' },
     };
     const data = await RequestUtils.createRequest(options, 'AllStops request failed');

--- a/src/utils/AllStopUtils.js
+++ b/src/utils/AllStopUtils.js
@@ -1,7 +1,6 @@
 // @flow
+import { ALL_STOPS } from './EnvUtils';
 import RequestUtils from './RequestUtils';
-import TokenUtils from './TokenUtils';
-import LogUtils from './LogUtils';
 
 const SEC_IN_MS = 1000;
 const MIN_IN_MS = SEC_IN_MS * 60;
@@ -11,12 +10,6 @@ const DEG_EQ_PRECISION = 5; // 5 degrees of precision is about a 1.1 meters, is 
 const DEG_NEARBY_PRECISION = 4; // 4 degrees of precision is about 11 meters, stop nearby
 const DEG_WALK_PRECISION = 3; // 3 degrees of precision is about 111 meters, stop walkable
 const DEG_KM_PRECISION = 2; // 3 degrees of precision is about 1 km, stop barely walkable
-
-/**
- * Array of all stops
- * @type {Promise<*>}
- */
-let allStops = RequestUtils.fetchWithRetry(fetchAllStops);
 
 /**
  * Used for finding stops at or nearby a point
@@ -55,7 +48,6 @@ let allStops = RequestUtils.fetchWithRetry(fetchAllStops);
 let allStopsCompareMaps = RequestUtils.fetchWithRetry(fetchPrecisionMaps);
 
 const updateFunc = async () => {
-    allStops = await RequestUtils.fetchWithRetry(fetchAllStops);
     allStopsCompareMaps = await RequestUtils.fetchWithRetry(fetchPrecisionMaps);
     return false;
 };
@@ -68,34 +60,18 @@ RequestUtils.updateObjectOnInterval(
 );
 
 async function fetchAllStops() {
-    try {
-        const authHeader = await TokenUtils.fetchAuthHeader();
+    const options = {
+        method: 'GET',
+        url: `http://${ALL_STOPS || 'localhost'}:5000/stops`,
+        headers: { 'Cache-Control': 'no-cache' },
+    };
+    const data = await RequestUtils.createRequest(options, 'AllStops request failed');
+    return JSON.parse(data);
+}
 
-        const options = {
-            method: 'GET',
-            url: 'https://gateway.api.cloud.wso2.com:443/t/mystop/tcat/v1/rest/Stops/GetAllStops',
-            headers:
-                {
-                    'Postman-Token': 'b688b636-87ea-4e04-9f3e-ba34e811e639',
-                    'Cache-Control': 'no-cache',
-                    Authorization: authHeader,
-                },
-        };
-
-        const stopsRequest = await RequestUtils.createRequest(options, 'allStops request failed');
-        if (stopsRequest) {
-            return JSON.parse(stopsRequest).map(stop => ({
-                name: stop.Name,
-                lat: stop.Latitude,
-                long: stop.Longitude,
-            }));
-        }
-    } catch (err) {
-        LogUtils.logErr(err, null, 'allStops error');
-        throw err;
-    }
-
-    return null;
+async function getAllStops() {
+    const allStops = await fetchAllStops();
+    return allStops;
 }
 
 function fetchPrecisionMaps() {
@@ -165,12 +141,12 @@ function isStop(point: Object) {
 }
 
 export default {
-    isStop,
-    isStopsWithinPrecision,
-    allStops,
-    DEG_EXACT_PRECISION,
     DEG_EQ_PRECISION,
+    DEG_EXACT_PRECISION,
+    DEG_KM_PRECISION,
     DEG_NEARBY_PRECISION,
     DEG_WALK_PRECISION,
-    DEG_KM_PRECISION,
+    getAllStops,
+    isStop,
+    isStopsWithinPrecision,
 };

--- a/src/utils/EnvUtils.js
+++ b/src/utils/EnvUtils.js
@@ -1,22 +1,18 @@
 // @flow
 const {
-    ALERTS,
-    ALL_STOPS,
     GHOPPER_BUS,
     GHOPPER_WALKING,
-    LIVE_TRACKING,
     MAP_MATCHING,
     NODE_ENV,
+    TCAT_SERVICE,
     TOKEN,
 } = process.env;
 
 export {
-    ALERTS,
-    ALL_STOPS,
     GHOPPER_BUS,
     GHOPPER_WALKING,
-    LIVE_TRACKING,
     MAP_MATCHING,
     NODE_ENV,
+    TCAT_SERVICE,
     TOKEN,
 };

--- a/src/utils/EnvUtils.js
+++ b/src/utils/EnvUtils.js
@@ -1,5 +1,7 @@
 // @flow
 const {
+    ALERTS,
+    ALL_STOPS,
     GHOPPER_BUS,
     GHOPPER_WALKING,
     LIVE_TRACKING,
@@ -9,6 +11,8 @@ const {
 } = process.env;
 
 export {
+    ALERTS,
+    ALL_STOPS,
     GHOPPER_BUS,
     GHOPPER_WALKING,
     LIVE_TRACKING,

--- a/src/utils/EnvUtils.js
+++ b/src/utils/EnvUtils.js
@@ -4,7 +4,7 @@ const {
     GHOPPER_WALKING,
     MAP_MATCHING,
     NODE_ENV,
-    TCAT_SERVICE,
+    PYTHON_APP,
     TOKEN,
 } = process.env;
 
@@ -13,6 +13,6 @@ export {
     GHOPPER_WALKING,
     MAP_MATCHING,
     NODE_ENV,
-    TCAT_SERVICE,
+    PYTHON_APP,
     TOKEN,
 };

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -1,5 +1,5 @@
 // @flow
-import { TCAT_SERVICE } from './EnvUtils';
+import { PYTHON_APP } from './EnvUtils';
 import LogUtils from './LogUtils';
 import RequestUtils from './RequestUtils';
 import TokenUtils from './TokenUtils';
@@ -7,7 +7,7 @@ import TokenUtils from './TokenUtils';
 async function fetchRTF(): Object {
     const options = {
         method: 'GET',
-        url: `http://${TCAT_SERVICE || 'localhost'}:5000/rtf`,
+        url: `http://${PYTHON_APP || 'localhost'}:5000/rtf`,
         headers: { 'Cache-Control': 'no-cache' },
     };
     const data = await RequestUtils.createRequest(options, 'Tracking request failed');

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -1,5 +1,5 @@
 // @flow
-import { LIVE_TRACKING } from './EnvUtils';
+import { TCAT_SERVICE } from './EnvUtils';
 import LogUtils from './LogUtils';
 import RequestUtils from './RequestUtils';
 import TokenUtils from './TokenUtils';
@@ -7,7 +7,7 @@ import TokenUtils from './TokenUtils';
 async function fetchRTF(): Object {
     const options = {
         method: 'GET',
-        url: `http://${LIVE_TRACKING || 'localhost'}:5000/rtf`,
+        url: `http://${TCAT_SERVICE || 'localhost'}:5000/rtf`,
         headers: { 'Cache-Control': 'no-cache' },
     };
     const data = await RequestUtils.createRequest(options, 'Tracking request failed');

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -4,10 +4,10 @@ import LogUtils from './LogUtils';
 import RequestUtils from './RequestUtils';
 import TokenUtils from './TokenUtils';
 
-async function fetchRTF() : Object {
+async function fetchRTF(): Object {
     const options = {
         method: 'GET',
-        url: `http://${LIVE_TRACKING || 'localhost'}:5000`,
+        url: `http://${LIVE_TRACKING || 'localhost'}:5000/rtf`,
         headers: { 'Cache-Control': 'no-cache' },
     };
     const data = await RequestUtils.createRequest(options, 'Tracking request failed');
@@ -27,7 +27,7 @@ async function fetchRTF() : Object {
  …
  ]
  */
-async function getTrackingResponse(requestData: Object) : Object {
+async function getTrackingResponse(requestData: Object): Object {
     LogUtils.log({ message: 'getTrackingResponse: entering function' });
 
     const trackingInformation = [];
@@ -146,7 +146,7 @@ async function getTrackingResponse(requestData: Object) : Object {
  * @param rtf
  * @returns Object
  */
-function getDelayInformation(stopID: String, tripID: String, rtf: Object) : ?Object {
+function getDelayInformation(stopID: String, tripID: String, rtf: Object): ?Object {
     // rtf param ensures the realtimeFeed doesn't update in the middle of execution
     // if invalid params or the trip is inactive
     if (!stopID

--- a/src/utils/TokenUtils.js
+++ b/src/utils/TokenUtils.js
@@ -90,6 +90,7 @@ async function fetchAuthHeader() {
     if (isAccessTokenExpired()) { // else get from API
         await RequestUtils.fetchWithRetry(fetchAccessToken);
     }
+
     if (credentials.access_token) {
         return `Bearer ${credentials.access_token}`;
     }

--- a/src/utils/TokenUtils.js
+++ b/src/utils/TokenUtils.js
@@ -49,11 +49,11 @@ function fetchAccessToken() {
         url: 'https://gateway.api.cloud.wso2.com:443/token',
         qs: { grant_type: 'client_credentials' },
         headers:
-                {
-                    'Postman-Token': '42201611-965d-4832-a4c5-060ad3ff3b83',
-                    'Cache-Control': 'no-cache',
-                    Authorization: basicAuthHeader,
-                },
+        {
+            'Postman-Token': '42201611-965d-4832-a4c5-060ad3ff3b83',
+            'Cache-Control': 'no-cache',
+            Authorization: basicAuthHeader,
+        },
     };
 
     return new Promise((resolve, reject) => {
@@ -90,7 +90,6 @@ async function fetchAuthHeader() {
     if (isAccessTokenExpired()) { // else get from API
         await RequestUtils.fetchWithRetry(fetchAccessToken);
     }
-
     if (credentials.access_token) {
         return `Bearer ${credentials.access_token}`;
     }


### PR DESCRIPTION
Issue #145 
- Replaced old code of fetching stops & alerts with new code to fetch both from the `transit-microservice`

`NOTE`: Not sure if somethings wrong w/ my linter? It seems to have added/removed some spaces in certain lines. Is my linter correct?

Screenshots of responses for `alerts` & `allStops`:
Alerts:
<img width="1439" alt="screen shot 2019-01-31 at 10 29 21 pm" src="https://user-images.githubusercontent.com/26048121/52100962-b81a2c80-25a7-11e9-9043-32247b012277.png">

All Stops:
<img width="1431" alt="screen shot 2019-01-31 at 10 29 13 pm" src="https://user-images.githubusercontent.com/26048121/52100963-b81a2c80-25a7-11e9-8af9-d16dc4eaa14d.png">
