### PR TITLE
Travis configuration for master, release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: node_js
+sudo: required
+node_js:
+- '10'
+services:
+- docker
+env:
+  global:
+  - secure: jWGLOvJobDm/Cs/LWQWTV2A8dSfSiocKxBd+c7gnyFBuRzfYTz0T0M22hJrcHZ1AqmrYRKvVWzygEeEb15jq7c8UGYE+vJd6B7Qo2EWgw2ikp8QXenbVlgzUFEAXsSE1/OwxrjxLlIf82xLLXn9boNmyttqSDCmrKc0PsLbytpWa0RwF+t4eUTYmgeTpuVaIUcTaDhZ9sJdjaONjhfDYvcZNQgB+PsJWBIhkim+zBhvMkYF6JGKnVYnDzEQQSzlDUZlB5jYJvJvUuv4ntERVlMU7YrXF9cSIPLpgMZnKUjMa47uc/2yik2PeYSiK4RDK6cY4fSo92PMqobxLcHqOZTZo2DldWNZ9tTZG3eLivmbKEVU+VKRYIIaGLpDbZJCsLRID9SdzBnVWPP1Z2Crdku6V1lrlTnQvCpsFFl1UckCFd4PIZvRDxI0vGPGGQYngc2Ik8jkAQSII+hSFdfYo7WPTrrW2XrChNi83QbdSdOGYQft2x1m8MuNCKWMhRC94Xu7iJ5Bt32VhIyR+PFd9sJVzoK31/aF5aoadrcPAYq2NRMC8gjch/5DkYXbCed/myFS3OJ5v5sYVYvJuXxWpMMm/a1TyKdINdRyp1AIYA9CQ2HLeanPZZzNcSX5VtIqvzIGxZYu0Rytz8eU154IIb/v/Bteud9zpxG2s4O1CEVg=
+  - secure: pX9lQu4Gw9rJZKyJzIH0rLO+LxIDPoU757+hIlImSDKhuueGjXoJNGM5DEsL7DV10peYaNAeOUVd9nMBpv4rIoqRrAHc363sTES084rsXBo6DwnETIbodg8gQqIuXyNLg119VYurNOwOAw3SnSwMh18vzsx0zrRbWHa4g+HRQmkkPL2ewtCUl7RGG+xeqTztqggWTFwoSvv4zPwQ+Lq+O+fa04AJqBppYSaQb7OHmDWvJlB631D4chhj1fVdjyqfOwlpFkcf0XdwsU7bjZPaOt+RNYzqU+J6Q10VcoWjDtH2jG/T7V6Sg6ek18iLqJnal5OH/XDZE/KJ37ZnjV6bY6BKS2IKDboOEEO2fUFZ4RKLp6SKN77Pb7hjlWn2FOPvUq/J26VgICcHjl3/oZQrCEzgLDfKFeK0qm1JJtsA4vnEJmPs4O9LD88ydv+/41zjhdyQPX1r+vpK0UKa4mKqkmBK7nPB/ZiKa8qpS3fuAZDy+0381ruf0bAdk/57tXzMr97p/dH++qucikMus9oUHs49sW7moo3869VDEx3eqbH9t3ehzYS5HKIOLgEdDQo+LR9iMODml1fu+ebWDIwKzZp1D07IEIeH3WtncHxX6j9dJJlye7hI59dT/6Xm5G32Yj+1TyEaVE3+CG3xFUh+pc5dDZbjVu+BQgX1Qxv7Gvw=
+jobs:
+  include:
+  - if: branch = release
+    env:
+    - NODE_IMAGE="transit-node"
+  - if: branch = master
+    env:
+    - NODE_IMAGE="transit-dev"
+deploy:
+  provider: script
+  script: bash docker_push
+  on:
+    branches:
+      only:
+      - master
+      - release
+script:
+- 

--- a/docker_push
+++ b/docker_push
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker build -t cornellappdev/"$NODE_IMAGE":"$TRAVIS_COMMIT" --no-cache .
+docker push cornellappdev/"$NODE_IMAGE":"$TRAVIS_COMMIT"


### PR DESCRIPTION
- Builds and pushes an image to `transit-node` if push happens on the release branch
- Builds and pushes an image to `transit-dev` if push happens on master branch (unless we want to use a dev branch)

Tested by building a dev image on this branch. Output can be seen here (under "Deploying Application"): https://travis-ci.com/cuappdev/ithaca-transit-backend/jobs/178874188#L509