### PR TITLE
Fix travis deploy script to support multiple branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,7 @@ deploy:
   provider: script
   script: bash docker_push
   on:
-    branches:
-      only:
-      - master
-      - release
+    all_branches: true
+    condition: $TRAVIS_BRANCH =~ ^master|release$
 script:
 - 


### PR DESCRIPTION
As the title says, the original syntax only recognized the first branch stated.

Just tested on this branch!