### PR TITLE
Handle ghopper errors properly

### DIFF
--- a/src/routers/v1/RouteRouter.js
+++ b/src/routers/v1/RouteRouter.js
@@ -23,23 +23,25 @@ class RouteRouter extends ApplicationRouter<Array<Object>> {
       end,
       originName,
       start,
-      time: departureTimeQuery,
+      time,
       uid,
     } = params;
 
     const isArriveBy = (arriveBy === '1' || arriveBy === true);
-    const routes = await RouteUtils.getRoutes(destinationName, end, start, departureTimeQuery, isArriveBy);
-    const request = {
-      arriveBy,
-      destinationName,
-      end: routes[0].endCoords,
-      originName,
-      routeId: routes[0].routeId,
-      start: routes[0].startCoords,
-      time: departureTimeQuery,
-      uid,
-    };
-    LogUtils.log({ category: 'routeRequest', request });
+    const routes = await RouteUtils.getRoutes(destinationName, end, start, time, isArriveBy);
+    if (routes.length > 0) {
+      const request = {
+        arriveBy,
+        destinationName,
+        end: routes[0].endCoords,
+        originName,
+        routeId: routes[0].routeId,
+        start: routes[0].startCoords,
+        time,
+        uid,
+      };
+      LogUtils.log({ category: 'routeRequest', request });
+    }
     AnalyticsUtils.assignRouteIdsAndCache(routes);
 
     return routes;

--- a/src/utils/GraphhopperUtils.js
+++ b/src/utils/GraphhopperUtils.js
@@ -149,7 +149,7 @@ async function fetchRoutes(end: string, start: string, departureTimeDateNow: str
   if (busRouteRequest && busRouteRequest.statusCode < 300) {
     busRoute = JSON.parse(busRouteRequest.body);
   } else {
-    throw LogUtils.logErr(
+    LogUtils.log(
       busRouteRequest && busRouteRequest.body,
       getGraphhopperBusParams(end, start, departureTimeDateNow, isArriveByQuery),
       `Routing failed: ${GHOPPER_BUS || 'undefined graphhopper bus env'}`,
@@ -159,7 +159,7 @@ async function fetchRoutes(end: string, start: string, departureTimeDateNow: str
   if (walkingRouteRequest && walkingRouteRequest.statusCode < 300) {
     walkingRoute = JSON.parse(walkingRouteRequest.body);
   } else {
-    throw LogUtils.logErr(
+    LogUtils.log(
       walkingRouteRequest && walkingRouteRequest.body,
       getGraphhopperWalkingParams(end, start),
       `Walking failed: ${GHOPPER_WALKING || 'undefined graphhopper walking env'}`,


### PR DESCRIPTION
Right now if ghopper fails to return any bus routes, we just throw an error. This makes the response something like this (https://transit-dev.cornellappdev.com/api/v1/route?arriveBy=0&destinationName=Current%20Location&end=42.43865970526117%2C-76.4841959719327&originName=Asbury%20%40%20Warren&start=42.524723%2C-76.472847&time=1552706100&uid=BFDA3D0E-1E38-4A66-ABBF-DAF1243B246B).

Instead of throwing an error, we should just log the error instead and continue to see if there are any walking routes.