### PR TITLE
Refactor RouteUtils

### DIFF
--- a/src/appdev/ApplicationRouter.js
+++ b/src/appdev/ApplicationRouter.js
@@ -102,7 +102,7 @@ class ApplicationRouter<T> {
     return async (req: Request, res: Response, next: NextFunction) => {
       try {
         const content = await this.content(req);
-        LogUtils.log({ path: this.getPath(), query: req.query, response: content });
+        LogUtils.log({ path: this.getPath(), query: req.query });
         res.json(new AppDevResponse(true, content));
       } catch (e) {
         if (e.message === 1) {


### PR DESCRIPTION
First of a few changes addressing #195.

List of changes made:

- Split shared code from `createSectionedRoute` and `getRoutes` into a helper function.
- There's an invariant that a `walkingRoute` will always be returned, I changed our code to anticipate that.
- `adjustRouteTimesIfNecessary` was being used in `RouteUtils`, this should be private to `ParseRouteUtils` to make the logic cleaner.

Screenshot verifying it works on devserver:

![IMG_CA1F295A32AA-1](https://user-images.githubusercontent.com/8889311/54161262-fe28a280-4427-11e9-9202-6a856ef0d189.jpeg)
