### PR TITLE
Update and fix graphhopper map image

### DIFF
--- a/docker-compose/map/Dockerfile
+++ b/docker-compose/map/Dockerfile
@@ -13,7 +13,8 @@ WORKDIR /usr/src/app/map-matching
 
 RUN mvn package -e -DskipTests
 RUN java -jar matching-web/target/graphhopper-map-matching-web-0.11-SNAPSHOT.jar import ../map.osm --vehicle=car,foot
-RUN rm -rf graph-cache
+
+COPY config.yml .
 
 EXPOSE 8989
 

--- a/docker-compose/map/config.yml
+++ b/docker-compose/map/config.yml
@@ -1,0 +1,15 @@
+graphhopper:
+  datareader.file: ../map-data/map.osm
+  graph.location: graph-cache
+  graph.flag_encoders: car,foot
+  prepare.ch.weightings: no
+
+server:
+  applicationConnectors:
+  - type: http
+    port: 8989
+    bindHost: 0.0.0.0
+  adminConnectors:
+  - type: http
+    port: 8990
+    bindHost: 0.0.0.0


### PR DESCRIPTION
More progress on #178

The graphhopper map image that I worked on for `0.11` wasn't working, I finally got around to fixing the issue –– this upgrades the graphhopper version from `0.9` to `0.11`!

This also lets use the `graph-cache`, so we can pre-build our images.