### PR TITLE
Add check to prevent PR from release to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,8 @@ deploy:
     all_branches: true
     condition: $TRAVIS_BRANCH =~ ^master|release$
 script:
-- 
+- if [[ "$TRAVIS_PULL_REQUEST" != "false" && "$TRAVIS_PULL_REQUEST_BRANCH" == "release" && "$TRAVIS_BRANCH" == "master" ]]; 
+  then 
+    exit 1; 
+  fi
+


### PR DESCRIPTION
I confirmed that if I change the command to `if [[ "$TRAVIS_PULL_REQUEST" != "false" && "$TRAVIS_PULL_REQUEST_BRANCH" == "kevin/travis" && "$TRAVIS_BRANCH" == "master" ]];` the build would fail
<img width="848" alt="Screen Shot 2019-03-23 at 2 40 53 AM" src="https://user-images.githubusercontent.com/26048121/54862735-50fe3600-4d15-11e9-8256-3be7f133edf3.png">


i'm not sure if this is right tho so pls double check