### PR TITLE
Update graphhopper-walking minor version to 0.12

### DIFF
--- a/docker-compose/ghopper-walking/Dockerfile
+++ b/docker-compose/ghopper-walking/Dockerfile
@@ -1,20 +1,22 @@
-FROM openjdk:8
+FROM maven:3.6.0-jdk-8-alpine
 
-RUN mkdir /usr/src/app
+RUN mkdir -p /usr/src/app
+RUN apk add git wget
+
 RUN git clone --single-branch -b tcat-map https://github.com/cuappdev/ithaca-transit-backend.git /usr/src/app
 
 WORKDIR /usr/src/app
 
-RUN apt-get update
-RUN apt-get -y install maven wget
-
-RUN git clone --single-branch -b 0.10 https://github.com/graphhopper/graphhopper.git
+RUN git clone --single-branch -b 0.12 https://github.com/graphhopper/graphhopper.git
+RUN wget https://s3.amazonaws.com/tcat-gtfs/tcat-ny-us.zip
 
 WORKDIR /usr/src/app/graphhopper
-RUN ./graphhopper.sh buildweb
+RUN ./graphhopper.sh --action build
 
-WORKDIR /usr/src/app
+RUN mv ../map.osm .
+
+COPY config.yml .
 
 EXPOSE 8987
 
-CMD java -Xmx1g -Xms1g -jar graphhopper/web/target/graphhopper-web-*-with-dep.jar datareader.file=map.osm jetty.port=8987 jetty.resourcebase=./graphhopper/web/src/main/webapp graph.flag_encoders=foot prepare.ch.weightings=no graph.location=./graph-cache
+CMD java -Xmx1g -Xms1g -jar web/target/graphhopper-web-*.jar server config.yml

--- a/docker-compose/ghopper-walking/config.yml
+++ b/docker-compose/ghopper-walking/config.yml
@@ -1,0 +1,36 @@
+graphhopper:
+  datareader.file: map.osm
+  graph.flag_encoders: foot
+  graph.location: ./graph-cache
+  prepare.ch.weightings: no
+  prepare.ch.edge_based: off
+  # avoid being stuck in a (oneway) subnetwork, see https://discuss.graphhopper.com/t/93
+  prepare.min_network_size: 200
+  prepare.min_one_way_network_size: 200
+
+# Dropwizard server configuration
+server:
+  applicationConnectors:
+  - type: http
+    port: 8987
+    bindHost: 0.0.0.0
+  requestLog:
+      appenders: []
+  adminConnectors:
+  - type: http
+    port: 8990
+    bindHost: 0.0.0.0
+# See https://www.dropwizard.io/1.3.8/docs/manual/configuration.html#logging
+logging:
+  appenders:
+  - type: file
+    timeZone: UTC
+    currentLogFilename: logs/graphhopper.log
+    logFormat: "%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+    archive: true
+    archivedLogFilenamePattern: ./logs/graphhopper-%d.log.gz
+    archivedFileCount: 30
+    neverBlock: true
+  - type: console
+    timeZone: UTC
+    logFormat: "%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"


### PR DESCRIPTION
This change is deployed in production, it saves us 0.4GB in RAM, and also updates the graphhopper-walking minor version from `0.10` to `0.12`. Addresses #178 and #180 as well!

The last one is the main `graphhopper` image, but I've been having issues with configuring the GTFS file –– I might make an issue in the `graphhopper` repository if I can't figure it out in the next few days.

<img width="1192" alt="Screen Shot 2019-03-23 at 3 11 07 PM" src="https://user-images.githubusercontent.com/8889311/54870552-707d7900-4d7e-11e9-9500-3593523ab889.png">

<img width="853" alt="Screen Shot 2019-03-23 at 3 15 12 PM" src="https://user-images.githubusercontent.com/8889311/54870556-796e4a80-4d7e-11e9-80a4-a732d9a5cb52.png">
