### PR TITLE
Add sorting for bus routes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "8987:8987"
 
   live-tracking:
-    image: cornellappdev/transit-python:cc0c4c048fe66036f3372d47703994ce84eb9317
+    image: cornellappdev/transit-python:04_15_19
     env_file: python.env
     ports:
       - "5000:5000"


### PR DESCRIPTION
Right now we don't do any sort of sorting for routes which leads to this issue sometimes where the first route is objectively worse than the second route.
![58383285_344407272747759_1276420402985304064_n](https://user-images.githubusercontent.com/26048121/56856038-548e6980-6920-11e9-8776-17a556eabeed.jpg)

Fixed:
<img width="323" alt="Screen Shot 2019-04-27 at 7 07 38 PM" src="https://user-images.githubusercontent.com/26048121/56856042-640db280-6920-11e9-8875-03fe8ab12bb3.png">
