### PR TITLE
Update /search endpoint to return lat and long in addition to placeID for googlePlace

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - /usr/src/app/node_modules
 
   ghopper:
-    image: cornellappdev/transit-ghopper:1.2
+    image: cornellappdev/transit-ghopper:04_16_19_2
     ports:
       - "8988:8988"
 
@@ -28,7 +28,7 @@ services:
       - "8987:8987"
 
   live-tracking:
-    image: cornellappdev/transit-python:04_15_19
+    image: cornellappdev/transit-python:4b5269be1ac67c45e7f20ebb399f0df95ef72299
     env_file: python.env
     ports:
       - "5000:5000"


### PR DESCRIPTION
### Tested and works on dev server!

### To make sure that ios doesn't break, we've decided to include lat and long in addition to placeID when we return stops.

### Now a request to `/search` looks like this: 
<img width="531" alt="Screen Shot 2019-05-03 at 2 36 35 PM" src="https://user-images.githubusercontent.com/13739525/57159080-13300b00-6db3-11e9-829e-9902d83a0811.png">
