### PR TITLE
Adds PlaceIDCoordsRouter for coord lookup

### DIFF
--- a/src/API.js
+++ b/src/API.js
@@ -21,6 +21,7 @@ class API extends ApplicationAPI {
       Routers.HelloWorldRouter,
       Routers.MultiRouteRouter,
       Routers.PlacesAutocompleteRouter,
+      Routers.PlaceIDCoordsRouter,
       Routers.RouteSelectedRouter,
       Routers.SearchRouter,
       Routers.TrackingRouter,

--- a/src/API.js
+++ b/src/API.js
@@ -21,7 +21,7 @@ class API extends ApplicationAPI {
       Routers.HelloWorldRouter,
       Routers.MultiRouteRouter,
       Routers.PlacesAutocompleteRouter,
-      Routers.PlaceIDCoordsRouter,
+      Routers.PlaceIDCoordinatesRouter,
       Routers.RouteSelectedRouter,
       Routers.SearchRouter,
       Routers.TrackingRouter,

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -5,6 +5,7 @@ import DocsRouter from './DocsRouter';
 import HelloWorldRouter from './v1/HelloWorldRouter';
 import MultiRouteRouter from './v1/MultiRouteRouter';
 import PlacesAutocompleteRouter from './v1/PlacesAutocompleteRouter';
+import PlaceIDCoordsRouter from './v1/PlaceIDCoordsRouter';
 import RouteRouter from './v1/RouteRouter';
 import RouteSelectedRouter from './v1/RouteSelectedRouter';
 import RouteV2Router from './v2/RouteRouter';
@@ -19,6 +20,7 @@ export default {
   HelloWorldRouter,
   MultiRouteRouter,
   PlacesAutocompleteRouter,
+  PlaceIDCoordsRouter,
   RouteRouter,
   RouteSelectedRouter,
   RouteV2Router,

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -5,7 +5,7 @@ import DocsRouter from './DocsRouter';
 import HelloWorldRouter from './v1/HelloWorldRouter';
 import MultiRouteRouter from './v1/MultiRouteRouter';
 import PlacesAutocompleteRouter from './v1/PlacesAutocompleteRouter';
-import PlaceIDCoordsRouter from './v1/PlaceIDCoordsRouter';
+import PlaceIDCoordinatesRouter from './v1/PlaceIDCoordinatesRouter';
 import RouteRouter from './v1/RouteRouter';
 import RouteSelectedRouter from './v1/RouteSelectedRouter';
 import RouteV2Router from './v2/RouteRouter';
@@ -20,7 +20,7 @@ export default {
   HelloWorldRouter,
   MultiRouteRouter,
   PlacesAutocompleteRouter,
-  PlaceIDCoordsRouter,
+  PlaceIDCoordinatesRouter,
   RouteRouter,
   RouteSelectedRouter,
   RouteV2Router,

--- a/src/routers/v1/PlaceIDCoordinatesRouter.js
+++ b/src/routers/v1/PlaceIDCoordinatesRouter.js
@@ -3,22 +3,22 @@ import type Request from 'express';
 import ApplicationRouter from '../../appdev/ApplicationRouter';
 import SearchUtils from '../../utils/SearchUtils';
 
-class PlaceIDCoordsRouter extends ApplicationRouter<Array<Object>> {
+class PlaceIDCoordinatesRouter extends ApplicationRouter<Array<Object>> {
   constructor() {
     super(['POST']);
   }
 
   getPath(): string {
-    return '/placeIDCoords/';
+    return '/placeIDCoordinates/';
   }
 
   async content(req: Request): Promise<any> {
     if (!req.body || !req.body.placeID || typeof req.body.placeID !== 'string') {
       return null;
     }
-    const placeIDCoords = await SearchUtils.getCoordsForPlaceID(req.body.placeID);
-    return placeIDCoords;
+    const placeIDCoordinates = await SearchUtils.getCoordsForPlaceID(req.body.placeID);
+    return placeIDCoordinates;
   }
 }
 
-export default new PlaceIDCoordsRouter().router;
+export default new PlaceIDCoordinatesRouter().router;

--- a/src/routers/v1/PlaceIDCoordsRouter.js
+++ b/src/routers/v1/PlaceIDCoordsRouter.js
@@ -1,0 +1,24 @@
+// @flow
+import type Request from 'express';
+import ApplicationRouter from '../../appdev/ApplicationRouter';
+import SearchUtils from '../../utils/SearchUtils';
+
+class PlaceIDCoordsRouter extends ApplicationRouter<Array<Object>> {
+  constructor() {
+    super(['POST']);
+  }
+
+  getPath(): string {
+    return '/placeIDCoords/';
+  }
+
+  async content(req: Request): Promise<any> {
+    if (!req.body || !req.body.placeID || typeof req.body.placeID !== 'string') {
+      return null;
+    }
+    const placeIDCoords = await SearchUtils.getCoordsForPlaceID(req.body.placeID);
+    return placeIDCoords;
+  }
+}
+
+export default new PlaceIDCoordsRouter().router;

--- a/src/utils/SearchUtils.js
+++ b/src/utils/SearchUtils.js
@@ -1,0 +1,46 @@
+// @flow
+import LRU from 'lru-cache';
+import RequestUtils from './RequestUtils';
+import Constants from './Constants';
+
+const placeIDToCoordsCacheOptions = {
+  max: 10000, // Maximum size of cache
+};
+const placeIDToCoordsCache = LRU(placeIDToCoordsCacheOptions);
+
+async function getCoordsForPlaceID(placeID: String): Object {
+  const cachedValue = placeIDToCoordsCache.get(placeID);
+  // Return an object of lat and long
+  if (cachedValue) return cachedValue;
+
+  // place id is not in cache so we must get lat and long
+  const options = {
+    ...Constants.GET_OPTIONS,
+    url: 'https://maps.googleapis.com/maps/api/place/details/json',
+    qs: {
+      placeid: placeID,
+      key: process.env.PLACES_KEY,
+    },
+  };
+
+  const placeIDDetailsRequest = await RequestUtils.createRequest(options, 'Place ID Details request failed');
+
+  if (placeIDDetailsRequest) {
+    const placeIDDetailsResult = JSON.parse(placeIDDetailsRequest);
+    const placeIDCoords = {
+      lat: placeIDDetailsResult.result.geometry.location.lat,
+      long: placeIDDetailsResult.result.geometry.location.lng,
+    };
+
+    placeIDToCoordsCache.set(placeID, placeIDCoords);
+    return placeIDCoords;
+  }
+  return {
+    lat: null,
+    long: null,
+  };
+}
+
+export default {
+  getCoordsForPlaceID,
+};

--- a/src/utils/SearchUtils.js
+++ b/src/utils/SearchUtils.js
@@ -13,11 +13,12 @@ async function getCoordsForPlaceID(placeID: String): Object {
   // Return an object of lat and long
   if (cachedValue) return cachedValue;
 
-  // place id is not in cache so we must get lat and long
+  // Place ID is not in cache so we must get lat and long
   const options = {
     ...Constants.GET_OPTIONS,
     url: 'https://maps.googleapis.com/maps/api/place/details/json',
     qs: {
+      fields: 'geometry',
       placeid: placeID,
       key: process.env.PLACES_KEY,
     },


### PR DESCRIPTION
This PR extracts the placeID to coordinate lookup from `SearchRouter` into its own `PlaceIDCoordsRouter` b/c on iOS we are currently making requests to GooglePlaces SDK for this lookup.

Tests:
<img width="1140" alt="Screen Shot 2019-08-29 at 12 30 33 PM" src="https://user-images.githubusercontent.com/26048121/63958871-010c6380-ca59-11e9-8ff7-c4a36a5ea6bc.png">
<img width="1141" alt="Screen Shot 2019-08-29 at 12 30 25 PM" src="https://user-images.githubusercontent.com/26048121/63958872-010c6380-ca59-11e9-931f-0060b358caaf.png">
