### PR TITLE
Utilize Graphhopper 0.11 for walking directions

### DIFF
--- a/docker-compose/ghopper/Dockerfile
+++ b/docker-compose/ghopper/Dockerfile
@@ -8,14 +8,21 @@ WORKDIR /usr/src/app
 RUN apt-get update
 RUN apt-get -y install maven wget
 
-RUN git clone --single-branch -b 0.10 https://github.com/graphhopper/graphhopper.git
+RUN git clone --single-branch -b 0.11 https://github.com/graphhopper/graphhopper.git
 RUN wget https://s3.amazonaws.com/tcat-gtfs/tcat-ny-us.zip
 
 WORKDIR /usr/src/app/graphhopper
-RUN ./graphhopper.sh buildweb
-
-WORKDIR /usr/src/app
+RUN ./graphhopper.sh --action build
 
 EXPOSE 8988
 
-CMD java -Xmx4g -Xms4g -jar graphhopper/web/target/graphhopper-web-*-with-dep.jar datareader.file=map.osm gtfs.file=tcat-ny-us.zip jetty.port=8988 jetty.resourcebase=./graphhopper/web/src/main/webapp graph.flag_encoders=pt prepare.ch.weightings=no graph.location=./graph-cache
+CMD java -Xmx4g -Xms4g \
+  -Dgraphhopper.datareader.file=../map.osm \
+  -Dgraphhopper.gtfs.file=../tcat-ny-us.zip \
+  -Dgraphhopper.jetty.resourcebase=./graphhopper/web/src/main/webapp \
+  -Dgraphhopper.graph.flag_encoders=pt \
+  -Dgraphhopper.prepare.ch.weightings=no \
+  -Dgraphhopper.graph.location=./graph-cache \
+  -Ddw.server.applicationConnectors[0].bindHost=0.0.0.0 \
+  -Ddw.server.applicationConnectors[0].port=8988 \
+  -jar web/target/graphhopper-web-0.11-SNAPSHOT.jar server config.yml

--- a/src/utils/ParseRouteUtils.js
+++ b/src/utils/ParseRouteUtils.js
@@ -433,7 +433,7 @@ function parseWalkingRoute(
  * @param destinationName
  * @returns {Promise<Array<Object>>}
  */
-function parseBusRoutes(busRoutes: Array<Object>, originName: string, destinationName: string): Promise<Array<Object>> {
+function parseRoutes(busRoutes: Array<Object>, originName: string, destinationName: string): Promise<Array<Object>> {
   return Promise.all(busRoutes.map(async (busRoute) => {
     try {
       // array containing legs of journey. e.g. walk, bus ride, walk
@@ -660,6 +660,6 @@ function parseBusRoutes(busRoutes: Array<Object>, originName: string, destinatio
 
 export default {
   condenseRoute,
-  parseBusRoutes,
+  parseRoutes,
   parseWalkingRoute,
 };


### PR DESCRIPTION
- Update Dockerfile to use Graphhopper 0.11 (even though 0.11 is currently deployed)
- Sometimes the Graphhopper (0.11) bus service will return walking directions in addition to bus directions (if the distance is close enough)
- If the bus service doesn't return walking directions, then we can make a separate request to the Grasshopper walking service to get directions.
- This is good cause we don't have to make extra requests to the walking service if it's not necessary
- Also fixes bug where we get 3 walking directions by filtering walking directions from the buffered requests

Currently deployed and tested on the dev server with the beta app