### PR TITLE
Replace last remove-able for loop with forEach

### DIFF
--- a/src/appdev/ApplicationAPI.js
+++ b/src/appdev/ApplicationAPI.js
@@ -39,9 +39,9 @@ class ApplicationAPI {
     AppDevUtilities.tryCheckAppDevURL(this.getPath());
     const middleware = this.middleware();
     const routerGroups = this.routerGroups();
-    for (let i = 0; i < middleware.length; i++) {
-      this.express.use(middleware[i]);
-    }
+    middleware.forEach((m) => {
+      this.express.use(m);
+    });
 
     Object.keys(routerGroups).forEach((version) => {
       const routers = routerGroups[version];


### PR DESCRIPTION
#177 I've addressed the last traditional for loop that could be replaced with a forEach

Sorry for the duplicate PR but I'll be breaking up my first PR into chunks because the massive change is breaking the dev server and I don't know why, so I'm testing each chunk. I've tested this change on the dev server (transit-dev:alanna1047), and I know for sure that it works.

Once I get all my other PRs in, I'll delete my old one.

When doing a search in VSCode, there are two more traditional `for` loops left because the first one we modify the array based on the index (so it didn't make sense to me to change that to a `forEach`) and the second one we're not looping through an array at all:
### Two results from searching
<img width="188" alt="Screen Shot 2019-09-14 at 4 10 47 PM" src="https://user-images.githubusercontent.com/13739525/64913250-8014c380-d70a-11e9-8496-b5e846685f96.png">

## First result 
### uses index to modify array while iterating through it
<img width="828" alt="Screen Shot 2019-09-14 at 4 11 15 PM" src="https://user-images.githubusercontent.com/13739525/64913251-84d97780-d70a-11e9-9bde-dd632e11ee08.png">

## Second result
### just loops through numbers, not an array
<img width="681" alt="Screen Shot 2019-09-14 at 4 11 34 PM" src="https://user-images.githubusercontent.com/13739525/64913256-99b60b00-d70a-11e9-811b-9f4bd57c7677.png">


