### PR TITLE
Clean up constants

### DIFF
--- a/src/routers/v1/MultiRouteRouter.js
+++ b/src/routers/v1/MultiRouteRouter.js
@@ -2,10 +2,9 @@
 import type Request from 'express';
 import AnalyticsUtils from '../../utils/AnalyticsUtils';
 import ApplicationRouter from '../../appdev/ApplicationRouter';
+import Constants from '../../utils/Constants';
 import LogUtils from '../../utils/LogUtils';
 import RouteUtils from '../../utils/RouteUtils';
-
-const CURRENT_LOCATION = 'Current Location';
 
 /**
  * Router object that returns an array of the best available route for each
@@ -39,7 +38,7 @@ class MultiRouteRouter extends ApplicationRouter<Array<Object>> {
 
     // get array of routes for each destination
     const multiRoutes = destinationNames.map((destinationName, index) => RouteUtils.getRoutes(
-      CURRENT_LOCATION,
+      Constants.CURRENT_LOCATION,
       destinationName,
       end[index],
       start,

--- a/src/routers/v1/PlacesAutocompleteRouter.js
+++ b/src/routers/v1/PlacesAutocompleteRouter.js
@@ -1,13 +1,10 @@
 // @flow
 import LRU from 'lru-cache';
 import ApplicationRouter from '../../appdev/ApplicationRouter';
+import Constants from '../../utils/Constants';
 import RequestUtils from '../../utils/RequestUtils';
 
-const cacheOptions = {
-  max: 10000,
-  maxAge: 1000 * 60 * 60 * 24 * 5,
-};
-const cache = LRU(cacheOptions);
+const cache = LRU(Constants.AUTOCOMPLETE_CACHE_OPTIONS);
 
 class PlacesAutocompleteRouter extends ApplicationRouter<string> {
   constructor() {
@@ -33,12 +30,12 @@ class PlacesAutocompleteRouter extends ApplicationRouter<string> {
     // not in cache
     const options = {
       method: 'GET',
-      url: 'https://maps.googleapis.com/maps/api/place/autocomplete/json',
+      url: Constants.GOOGLE_AUTOCOMPLETE_URL,
       qs: {
         input: query,
         key: process.env.PLACES_KEY,
-        location: '42.4440,-76.5019',
-        radius: 24140,
+        location: Constants.GOOGLE_PLACE_LOCATION,
+        radius: Constants.AUTOCOMPLETE_RADIUS,
         strictbounds: '',
       },
     };

--- a/src/routers/v1/SearchRouter.js
+++ b/src/routers/v1/SearchRouter.js
@@ -6,11 +6,7 @@ import RequestUtils from '../../utils/RequestUtils';
 import SearchUtils from '../../utils/SearchUtils';
 import Constants from '../../utils/Constants';
 
-const queryToPredictionsCacheOptions = {
-  max: 10000, // Maximum size of cache
-  maxAge: 1000 * 60 * 60 * 24 * 5, // Maximum age in milliseconds
-};
-const queryToPredictionsCache = LRU(queryToPredictionsCacheOptions);
+const queryToPredictionsCache = LRU(Constants.QUERY_PREDICTIONS_CACHE_OPTIONS);
 
 class SearchRouter extends ApplicationRouter<Array<Object>> {
   constructor() {

--- a/src/utils/AllStopUtils.js
+++ b/src/utils/AllStopUtils.js
@@ -3,6 +3,9 @@ import Constants from './Constants';
 import { PYTHON_APP } from './EnvUtils';
 import RequestUtils from './RequestUtils';
 
+// TODO: investigate why importing from Constants.js results in failure of getting routes
+const DEG_EQ_PRECISION = 5; // 5 degrees of precision is about a 1.1 meters, is a stop
+
 /**
  * Used for finding stops at or nearby a point
  * Use getPrecisionMap(precision) to access.
@@ -62,7 +65,7 @@ async function fetchAllStops() {
 
 function fetchPrecisionMaps() {
   const maps = {};
-  maps[Constants.DEG_EQ_PRECISION] = getPrecisionMap(Constants.DEG_EQ_PRECISION);
+  maps[DEG_EQ_PRECISION] = getPrecisionMap(DEG_EQ_PRECISION);
   return maps;
 }
 
@@ -72,8 +75,9 @@ function fetchPrecisionMaps() {
  * @param degreesPrecision
  * @returns {Promise<void>}
  */
-async function getPrecisionMap(degreesPrecision: ?number = Constants.DEG_EQ_PRECISION) {
-  if (degreesPrecision < Constants.DEG_MIN_PRECISION
+async function getPrecisionMap(degreesPrecision: ?number = DEG_EQ_PRECISION) {
+  if (
+    degreesPrecision < Constants.DEG_MIN_PRECISION
     || degreesPrecision > Constants.DEG_MAX_PRECISION
   ) {
     return null;
@@ -125,7 +129,7 @@ async function isStopsWithinPrecision(point: Object, degreesPrecision: ?number =
  * @returns {Promise<boolean>}
  */
 function isStop(point: Object) {
-  return isStopsWithinPrecision(point, Constants.DEG_EQ_PRECISION);
+  return isStopsWithinPrecision(point, DEG_EQ_PRECISION);
 }
 
 export default {

--- a/src/utils/AllStopUtils.js
+++ b/src/utils/AllStopUtils.js
@@ -3,15 +3,6 @@ import Constants from './Constants';
 import { PYTHON_APP } from './EnvUtils';
 import RequestUtils from './RequestUtils';
 
-const SEC_IN_MS = 1000;
-const MIN_IN_MS = SEC_IN_MS * 60;
-const HOUR_IN_MS = MIN_IN_MS * 60;
-const DEG_EXACT_PRECISION = 6; // 6 degrees of precision is about a 111 mm, is exact point
-const DEG_EQ_PRECISION = 5; // 5 degrees of precision is about a 1.1 meters, is a stop
-const DEG_NEARBY_PRECISION = 4; // 4 degrees of precision is about 11 meters, stop nearby
-const DEG_WALK_PRECISION = 3; // 3 degrees of precision is about 111 meters, stop walkable
-const DEG_KM_PRECISION = 2; // 3 degrees of precision is about 1 km, stop barely walkable
-
 /**
  * Used for finding stops at or nearby a point
  * Use getPrecisionMap(precision) to access.
@@ -55,8 +46,8 @@ const updateFunc = async () => {
 
 RequestUtils.updateObjectOnInterval(
   updateFunc,
-  HOUR_IN_MS,
-  MIN_IN_MS,
+  Constants.HOUR_IN_MS,
+  Constants.MIN_IN_MS,
   null,
 );
 
@@ -71,7 +62,7 @@ async function fetchAllStops() {
 
 function fetchPrecisionMaps() {
   const maps = {};
-  maps[DEG_EQ_PRECISION] = getPrecisionMap(DEG_EQ_PRECISION);
+  maps[Constants.DEG_EQ_PRECISION] = getPrecisionMap(Constants.DEG_EQ_PRECISION);
   return maps;
 }
 
@@ -81,8 +72,9 @@ function fetchPrecisionMaps() {
  * @param degreesPrecision
  * @returns {Promise<void>}
  */
-async function getPrecisionMap(degreesPrecision: ?number = DEG_EQ_PRECISION) {
-  if (degreesPrecision < 1 || degreesPrecision > 6) {
+async function getPrecisionMap(degreesPrecision: ?number = Constants.DEG_EQ_PRECISION) {
+  if (degreesPrecision < Constants.DEG_MIN_PRECISION
+    || degreesPrecision > Constants.DEG_MAX_PRECISION) {
     return null;
   }
   const stops = await fetchAllStops();
@@ -108,7 +100,7 @@ async function getPrecisionMap(degreesPrecision: ?number = DEG_EQ_PRECISION) {
  * @param degreesPrecision
  * @returns {Promise<boolean>}
  */
-async function isStopsWithinPrecision(point: Object, degreesPrecision: ?number = DEG_EQ_PRECISION) {
+async function isStopsWithinPrecision(point: Object, degreesPrecision: ?number = Constants.DEG_EQ_PRECISION) {
   const stops = await getPrecisionMap(degreesPrecision);
   const lat = parseFloat(point.lat).toFixed(degreesPrecision);
   let found = stops[lat]; // found stop(s) at lat
@@ -132,15 +124,10 @@ async function isStopsWithinPrecision(point: Object, degreesPrecision: ?number =
  * @returns {Promise<boolean>}
  */
 function isStop(point: Object) {
-  return isStopsWithinPrecision(point, DEG_EQ_PRECISION);
+  return isStopsWithinPrecision(point, Constants.DEG_EQ_PRECISION);
 }
 
 export default {
-  DEG_EQ_PRECISION,
-  DEG_EXACT_PRECISION,
-  DEG_KM_PRECISION,
-  DEG_NEARBY_PRECISION,
-  DEG_WALK_PRECISION,
   fetchAllStops,
   isStop,
   isStopsWithinPrecision,

--- a/src/utils/AllStopUtils.js
+++ b/src/utils/AllStopUtils.js
@@ -74,7 +74,8 @@ function fetchPrecisionMaps() {
  */
 async function getPrecisionMap(degreesPrecision: ?number = Constants.DEG_EQ_PRECISION) {
   if (degreesPrecision < Constants.DEG_MIN_PRECISION
-    || degreesPrecision > Constants.DEG_MAX_PRECISION) {
+    || degreesPrecision > Constants.DEG_MAX_PRECISION
+  ) {
     return null;
   }
   const stops = await fetchAllStops();

--- a/src/utils/AnalyticsUtils.js
+++ b/src/utils/AnalyticsUtils.js
@@ -1,12 +1,10 @@
 // @flow
 import crypto from 'crypto';
 import LRU from 'lru-cache';
+import Constants from './Constants';
 import LogUtils from './LogUtils';
 
-const routesCalculationsCache = LRU({
-  max: 1000, // max 1000 routes in storage
-  maxAge: 1000 * 60 * 15, // max age 15 minutes
-});
+const routesCalculationsCache = LRU(Constants.ROUTES_CALC_CACHE_OPTIONS);
 
 function getUniqueId(numBytes: ?number = 10) {
   return crypto.randomBytes(numBytes).toString('hex');

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -1,6 +1,5 @@
 /* Cache constants */
 // A cache containing Google Autocomplete results
-// TODO: Remove - it is duplicated with QUERY_PREDICTIONS_CACHE_OPTIONS
 const AUTOCOMPLETE_CACHE_OPTIONS = {
   max: 10000, // Max 10000 autocomplete results
   maxAge: 1000 * 60 * 60 * 24 * 5, // Max age in 5 days
@@ -11,6 +10,7 @@ const ROUTES_CALC_CACHE_OPTIONS = {
   max: 1000, // Max 1000 routes
   maxAge: 1000 * 60 * 15, // Max age in 15 minutes
 };
+
 // A cache mapping a /search's request query string to its Google autocomplete predictions
 const QUERY_PREDICTIONS_CACHE_OPTIONS = {
   max: 10000, // Max 1000 predictions

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -1,5 +1,58 @@
-const THREE_SEC_IN_MS = 3000;
+/* Cache constants */
+const AUTOCOMPLETE_CACHE_OPTIONS = {
+  max: 10000,
+  maxAge: 1000 * 60 * 60 * 24 * 5,
+};
+const ROUTES_CALC_CACHE_OPTIONS = {
+  max: 1000, // max 1000 routes in storage
+  maxAge: 1000 * 60 * 15, // max age 15 minutes
+};
+const QUERY_PREDICTIONS_CACHE_OPTIONS = {
+  max: 10000, // Maximum size of cache
+  maxAge: 1000 * 60 * 60 * 24 * 5, // Maximum age in milliseconds
+};
 
+/* Count constants */
+const MIN_FUZZ_RATIO = 75;
+
+/* Delay Buffer constants */
+// buffer to account for routes in past 20 minutes with delays
+const FIRST_DELAY_BUFFER_IN_MINUTES = 20;
+// additional buffer to account for time needed to walk from current location to bus stop
+const SECOND_DELAY_BUFFER_IN_MINUTES = 40;
+
+/* Distance & Speed constants */
+// > 3.0 suggests getting off bus earlier and walk half a mile instead of waiting longer
+const MAX_WALK_DIST_PER_LEG = 2000;
+const AUTOCOMPLETE_RADIUS = 24140;
+const WALK_SPEED = 3.0;
+
+/* Degrees Precision constants */
+const DEG_EQ_PRECISION = 5; // 5 degrees of precision is about a 1.1 meters, is a stop
+const DEG_EXACT_PRECISION = 6; // 6 degrees of precision is about a 111 mm, is exact point
+const DEG_KM_PRECISION = 2; // 3 degrees of precision is about 1 km, stop barely walkable
+const DEG_MAX_PRECISION = 6;
+const DEG_MIN_PRECISION = 1;
+const DEG_NEARBY_PRECISION = 4; // 4 degrees of precision is about 11 meters, stop nearby
+const DEG_WALK_PRECISION = 3; // 3 degrees of precision is about 111 meters, stop walkable
+
+/* String & URL constants */
+const BUS_STOP = 'busStop';
+const CURRENT_LOCATION = 'Current Location';
+const GOOGLE_AUTOCOMPLETE_URL = 'https://maps.googleapis.com/maps/api/place/autocomplete/json';
+const GOOGLE_PLACE = 'googlePlace';
+const GOOGLE_PLACE_LOCATION = '42.4440,-76.5019';
+const GOOGLE_PLACES_URL = 'https://maps.googleapis.com/maps/api/place/details/json';
+const TOKEN_URL = 'https://gateway.api.cloud.wso2.com:443/token';
+
+/* Time constants */
+const SEC_IN_MS = 1000;
+const MIN_IN_MS = SEC_IN_MS * 60;
+const HOUR_IN_MS = MIN_IN_MS * 60;
+const THREE_SEC_IN_MS = 3000;
+const TOKEN_EXPIRATION_WINDOW_IN_MS = 500;
+
+/* Request constants */
 const GET_OPTIONS = {
   method: 'GET',
   headers: { 'Cache-Control': 'no-cache' },
@@ -7,5 +60,32 @@ const GET_OPTIONS = {
 };
 
 export default {
+  AUTOCOMPLETE_CACHE_OPTIONS,
+  BUS_STOP,
+  CURRENT_LOCATION,
+  DEG_EQ_PRECISION,
+  DEG_EXACT_PRECISION,
+  DEG_KM_PRECISION,
+  DEG_MAX_PRECISION,
+  DEG_MIN_PRECISION,
+  DEG_NEARBY_PRECISION,
+  DEG_WALK_PRECISION,
+  FIRST_DELAY_BUFFER_IN_MINUTES,
   GET_OPTIONS,
+  GOOGLE_AUTOCOMPLETE_URL,
+  GOOGLE_PLACE,
+  GOOGLE_PLACE_LOCATION,
+  GOOGLE_PLACES_URL,
+  HOUR_IN_MS,
+  MIN_FUZZ_RATIO,
+  MAX_WALK_DIST_PER_LEG,
+  QUERY_PREDICTIONS_CACHE_OPTIONS,
+  AUTOCOMPLETE_RADIUS,
+  ROUTES_CALC_CACHE_OPTIONS,
+  SEC_IN_MS,
+  SECOND_DELAY_BUFFER_IN_MINUTES,
+  THREE_SEC_IN_MS,
+  TOKEN_EXPIRATION_WINDOW_IN_MS,
+  TOKEN_URL,
+  WALK_SPEED,
 };

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -1,12 +1,17 @@
 /* Cache constants */
+// A cache containing Google Autocomplete results
+// TODO: Remove - it is duplicated with QUERY_PREDICTIONS_CACHE_OPTIONS
 const AUTOCOMPLETE_CACHE_OPTIONS = {
   max: 10000, // Max 10000 autocomplete results
   maxAge: 1000 * 60 * 60 * 24 * 5, // Max age in 5 days
 };
+
+// A cache containing saved routes IDs to routes
 const ROUTES_CALC_CACHE_OPTIONS = {
   max: 1000, // Max 1000 routes
   maxAge: 1000 * 60 * 15, // Max age in 15 minutes
 };
+// A cache mapping a /search's request query string to its Google autocomplete predictions
 const QUERY_PREDICTIONS_CACHE_OPTIONS = {
   max: 10000, // Max 1000 predictions
   maxAge: 1000 * 60 * 60 * 24 * 5, // Max age in 5 days
@@ -17,9 +22,9 @@ const QUERY_PREDICTIONS_CACHE_OPTIONS = {
 const MIN_FUZZ_RATIO = 75;
 
 /* Delay Buffer constants */
-// buffer to account for routes in past 20 minutes with delays
+// A buffer to account for routes in past 20 minutes with delays
 const FIRST_DELAY_BUFFER_IN_MINUTES = 20;
-// additional buffer to account for time needed to walk from current location to bus stop
+// An additional buffer to account for time needed to walk from current location to bus stop
 const SECOND_DELAY_BUFFER_IN_MINUTES = 40;
 
 /* Distance & Speed constants */
@@ -31,11 +36,11 @@ const WALK_SPEED = 3.0;
 
 /* Degrees Precision constants */
 const DEG_MIN_PRECISION = 1;
-const DEG_KM_PRECISION = 2; // 3 degrees of precision is about 1 km, stop barely walkable
-const DEG_WALK_PRECISION = 3; // 3 degrees of precision is about 111 meters, stop walkable
-const DEG_NEARBY_PRECISION = 4; // 4 degrees of precision is about 11 meters, stop nearby
-const DEG_EQ_PRECISION = 5; // 5 degrees of precision is about a 1.1 meters, is a stop
-const DEG_EXACT_PRECISION = 6; // 6 degrees of precision is about a 111 mm, is exact point
+const DEG_KM_PRECISION = 2; // 2 degrees of precision is about 1 km, a barely walkable stop
+const DEG_WALK_PRECISION = 3; // 3 degrees of precision is about 111 meters, a walkable stop
+const DEG_NEARBY_PRECISION = 4; // 4 degrees of precision is about 11 meters, a nearby stop
+const DEG_EQ_PRECISION = 5; // 5 degrees of precision is about 1.1 meters, a stop
+const DEG_EXACT_PRECISION = 6; // 6 degrees of precision is about 111 mm, an exact point
 const DEG_MAX_PRECISION = 6;
 
 /* String & URL constants */

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -1,18 +1,19 @@
 /* Cache constants */
 const AUTOCOMPLETE_CACHE_OPTIONS = {
-  max: 10000,
-  maxAge: 1000 * 60 * 60 * 24 * 5,
+  max: 10000, // Max 10000 autocomplete results
+  maxAge: 1000 * 60 * 60 * 24 * 5, // Max age in 5 days
 };
 const ROUTES_CALC_CACHE_OPTIONS = {
-  max: 1000, // max 1000 routes in storage
-  maxAge: 1000 * 60 * 15, // max age 15 minutes
+  max: 1000, // Max 1000 routes
+  maxAge: 1000 * 60 * 15, // Max age in 15 minutes
 };
 const QUERY_PREDICTIONS_CACHE_OPTIONS = {
-  max: 10000, // Maximum size of cache
-  maxAge: 1000 * 60 * 60 * 24 * 5, // Maximum age in milliseconds
+  max: 10000, // Max 1000 predictions
+  maxAge: 1000 * 60 * 60 * 24 * 5, // Max age in 5 days
 };
 
 /* Count constants */
+// The minimum fuzzy string matching ratio that a word has to match a target word for /search
 const MIN_FUZZ_RATIO = 75;
 
 /* Delay Buffer constants */
@@ -24,17 +25,18 @@ const SECOND_DELAY_BUFFER_IN_MINUTES = 40;
 /* Distance & Speed constants */
 // > 3.0 suggests getting off bus earlier and walk half a mile instead of waiting longer
 const MAX_WALK_DIST_PER_LEG = 2000;
+// The distance (in meters) within which to return Google place results for autocomplete.
 const AUTOCOMPLETE_RADIUS = 24140;
 const WALK_SPEED = 3.0;
 
 /* Degrees Precision constants */
+const DEG_MIN_PRECISION = 1;
+const DEG_KM_PRECISION = 2; // 3 degrees of precision is about 1 km, stop barely walkable
+const DEG_WALK_PRECISION = 3; // 3 degrees of precision is about 111 meters, stop walkable
+const DEG_NEARBY_PRECISION = 4; // 4 degrees of precision is about 11 meters, stop nearby
 const DEG_EQ_PRECISION = 5; // 5 degrees of precision is about a 1.1 meters, is a stop
 const DEG_EXACT_PRECISION = 6; // 6 degrees of precision is about a 111 mm, is exact point
-const DEG_KM_PRECISION = 2; // 3 degrees of precision is about 1 km, stop barely walkable
 const DEG_MAX_PRECISION = 6;
-const DEG_MIN_PRECISION = 1;
-const DEG_NEARBY_PRECISION = 4; // 4 degrees of precision is about 11 meters, stop nearby
-const DEG_WALK_PRECISION = 3; // 3 degrees of precision is about 111 meters, stop walkable
 
 /* String & URL constants */
 const BUS_STOP = 'busStop';

--- a/src/utils/GraphhopperUtils.js
+++ b/src/utils/GraphhopperUtils.js
@@ -2,14 +2,9 @@ import {
   GHOPPER_BUS,
   GHOPPER_WALKING,
 } from './EnvUtils';
+import Constants from './Constants';
 import LogUtils from './LogUtils';
 import RequestUtils from './RequestUtils';
-
-// buffer to account for routes in past 20 minutes with delays
-const FIRST_DELAY_BUFFER_IN_MINUTES = 20;
-
-// additional buffer to account for time needed to walk from current location to bus stop
-const SECOND_DELAY_BUFFER_IN_MINUTES = 40;
 
 /**
  * https://graphhopper.com/api/1/docs/routing/#output
@@ -28,9 +23,9 @@ const getGraphhopperBusParams = (
   'ch.disable': true,
   'pt.arrive_by': arriveBy,
   'pt.earliest_departure_time': getDepartureTimeDate(departureTimeQuery, arriveBy, delayBufferMinutes),
-  'pt.max_walk_distance_per_leg': 2000,
+  'pt.max_walk_distance_per_leg': Constants.MAX_WALK_DIST_PER_LEG,
   'pt.profile': true,
-  'pt.walk_speed': 3.0, // > 3.0 suggests getting off bus earlier and walk half a mile instead of waiting longer
+  'pt.walk_speed': Constants.WALK_SPEED,
   elevation: false,
   point: [start, end],
   points_encoded: false,
@@ -220,7 +215,7 @@ async function fetchRoutes(end: string, start: string, departureTimeDateNow: str
     start,
     departureTimeDateNow,
     isArriveByQuery,
-    FIRST_DELAY_BUFFER_IN_MINUTES,
+    Constants.FIRST_DELAY_BUFFER_IN_MINUTES,
     sharedOptions,
   );
 
@@ -230,7 +225,7 @@ async function fetchRoutes(end: string, start: string, departureTimeDateNow: str
     start,
     departureTimeDateNow,
     isArriveByQuery,
-    SECOND_DELAY_BUFFER_IN_MINUTES,
+    Constants.SECOND_DELAY_BUFFER_IN_MINUTES,
     sharedOptions,
   );
 
@@ -275,7 +270,13 @@ async function fetchRoutes(end: string, start: string, departureTimeDateNow: str
   } else {
     LogUtils.log(
       busRouteBufferedFirstRequest && busRouteBufferedFirstRequest.body,
-      getGraphhopperBusParams(end, start, departureTimeDateNow, isArriveByQuery, FIRST_DELAY_BUFFER_IN_MINUTES),
+      getGraphhopperBusParams(
+        end,
+        start,
+        departureTimeDateNow,
+        isArriveByQuery,
+        Constants.FIRST_DELAY_BUFFER_IN_MINUTES,
+      ),
       `Routing failed: ${GHOPPER_BUS || 'undefined graphhopper bus env'}`,
     );
   }
@@ -286,7 +287,13 @@ async function fetchRoutes(end: string, start: string, departureTimeDateNow: str
   } else {
     LogUtils.log(
       busRouteBufferedSecondRequest && busRouteBufferedSecondRequest.body,
-      getGraphhopperBusParams(end, start, departureTimeDateNow, isArriveByQuery, SECOND_DELAY_BUFFER_IN_MINUTES),
+      getGraphhopperBusParams(
+        end,
+        start,
+        departureTimeDateNow,
+        isArriveByQuery,
+        Constants.SECOND_DELAY_BUFFER_IN_MINUTES,
+      ),
       `Routing failed: ${GHOPPER_BUS || 'undefined graphhopper bus env'}`,
     );
   }

--- a/src/utils/TokenUtils.js
+++ b/src/utils/TokenUtils.js
@@ -1,6 +1,7 @@
 // @flow
 import request from 'request';
 
+import Constants from './Constants';
 import { TOKEN } from './EnvUtils';
 import LogUtils from './LogUtils';
 
@@ -25,11 +26,10 @@ function fetchAccessToken(): void {
   const basicAuthHeader = `Basic ${credentials.basic_token}`;
   const options = {
     method: 'POST',
-    url: 'https://gateway.api.cloud.wso2.com:443/token',
+    url: Constants.TOKEN_URL,
     qs: { grant_type: 'client_credentials' },
     headers: {
       Authorization: basicAuthHeader,
-      'Postman-Token': '42201611-965d-4832-a4c5-060ad3ff3b83',
       'Cache-Control': 'no-cache',
     },
   };

--- a/src/utils/TokenUtils.js
+++ b/src/utils/TokenUtils.js
@@ -5,7 +5,6 @@ import Constants from './Constants';
 import { TOKEN } from './EnvUtils';
 import LogUtils from './LogUtils';
 
-const TOKEN_EXPIRATION_WINDOW_IN_MS = 500;
 let credentials = { basic_token: TOKEN, access_token: '', expiration_date: '' };
 
 function isAccessTokenExpired(): boolean {
@@ -15,7 +14,7 @@ function isAccessTokenExpired(): boolean {
 
   const currentTime = new Date().getTime();
   const tokenExpirationTime = (new Date(credentials.expiration_date)).getTime();
-  return tokenExpirationTime - currentTime < TOKEN_EXPIRATION_WINDOW_IN_MS;
+  return tokenExpirationTime - currentTime < Constants.TOKEN_EXPIRATION_WINDOW_IN_MS;
 }
 
 function fetchAccessToken(): void {


### PR DESCRIPTION
Centralized all the constants in one file, and removed the postman token because it was useless.

Again, sorry for the duplicate PR--for some reason, using the RETRY_COUNT constant in RequestUtils.js broke everything. Will be deleting the original PR once this gets merged in.

Currently testing on dev server (transit-dev:alanna) because it sometimes works and sometimes doesn't work 