### PR TITLE
Return routes that end at a time before the arriveBy time

### DIFF
--- a/src/routers/v1/RouteRouter.js
+++ b/src/routers/v1/RouteRouter.js
@@ -27,7 +27,7 @@ class RouteRouter extends ApplicationRouter<Array<Object>> {
       uid,
     } = params;
 
-    const isArriveBy = (arriveBy === '1' || arriveBy === true);
+    const isArriveBy = (arriveBy === '1' || arriveBy === true || arriveBy === 'true' || arriveBy === 'True');
     const routes = await RouteUtils.getRoutes(originName, destinationName, end, start, time, isArriveBy);
     const containsTransfer = routes.find(route => RouteUtils.routeContainsTransfer(route)) !== undefined;
     if (routes.length > 0 && containsTransfer) {


### PR DESCRIPTION
Fixed #253, which was that when a client indeed passes in a boolean `arriveBy`, `true`, when that gets passed in as a request to the backend, the type of `arriveBy` is now tragically a String, `'true'`. The unfortunate disaster is we only check for `'1'` or `true`, but not `'true'`.


Tested on dev server and ensured that we do return routes that have an ending time before the `arriveBy` time.

# I tested this on the dev server (transit-dev:alanna-arrive) and it works, and here is the evidence:

Here is the GET request I used: https://transit-testflight.cornellappdev.com/api/v1/route?arriveBy=true&end=42.4426153,-76.50927779999999&start=42.4439852,-76.48287359999999&time=1568948285&destinationName=Dufield%20Hall&originName=Statler%20Hall

Notice the arriveBy is true and the time is 1568948285, which is 
<img width="677" alt="Screen Shot 2019-09-19 at 11 06 37 PM" src="https://user-images.githubusercontent.com/13739525/65296540-cc109f80-db32-11e9-962a-461784ddc6f7.png">


# Here was what we were returning before:
<img width="533" alt="Screen Shot 2019-09-19 at 11 06 11 PM" src="https://user-images.githubusercontent.com/13739525/65296526-bbf8c000-db32-11e9-9e70-0296b097930d.png">

# And this is what is returned now:
<img width="534" alt="Screen Shot 2019-09-19 at 11 05 35 PM" src="https://user-images.githubusercontent.com/13739525/65296553-d7fc6180-db32-11e9-9356-f81208998a7d.png">

# However, you may notice that the UI doesn't reflect that. 
I suspect that iOS isn't actually passing in the true parameter, because I'm not sure why I would get my results by making a direct request to backend vs testing it on the Transit Beta App. @Omarrasheed @usubzero 

## **Update: Omar just told me that they didn't push the new code that fixes this on iOS!


