### PR TITLE
Return v2/routes that have an end time before arriveBy time

### DIFF
--- a/src/routers/v2/RouteRouter.js
+++ b/src/routers/v2/RouteRouter.js
@@ -18,12 +18,14 @@ class RouteRouter extends ApplicationRouter<Object> {
     const {
       destinationName,
       end,
-      isArriveBy,
+      arriveBy,
       originName,
       start,
       time,
       uid,
     } = req.body;
+
+    const isArriveBy = (arriveBy === '1' || arriveBy === true || arriveBy === 'true' || arriveBy === 'True');
 
     const isOriginBusStop = await RouteUtils.isBusStop(originName);
     const originBusStopName = isOriginBusStop ? originName : null;


### PR DESCRIPTION
Updates the `arriveBy` bug for v2. 

We need to change the request parameter `isArriveBy` to `arriveBy` because iOS did not read the swagger docs. Because this is urgent, this PR won't deal with updating the docs -- just updating parameters so we can get the `arriveBy` working ASAP

![IMG_2618](https://user-images.githubusercontent.com/13739525/65300480-9b843200-db41-11e9-8ee3-069f77c463c8.PNG)
