### PR TITLE
Add ApplePlaces & AppleSearchRouter

### DIFF
--- a/src/API.js
+++ b/src/API.js
@@ -17,6 +17,8 @@ class API extends ApplicationAPI {
     const sharedRouters = [
       Routers.AlertsRouter,
       Routers.AllStopsRouter,
+      Routers.ApplePlacesRouter,
+      Routers.AppleSearchRouter,
       Routers.DelayRouter,
       Routers.HelloWorldRouter,
       Routers.MultiRouteRouter,

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -1,5 +1,7 @@
 import AlertsRouter from './v1/AlertsRouter';
 import AllStopsRouter from './v1/AllStopsRouter';
+import ApplePlacesRouter from './v1/ApplePlacesRouter';
+import AppleSearchRouter from './v1/AppleSearchRouter';
 import DelayRouter from './v1/DelayRouter';
 import DocsRouter from './DocsRouter';
 import HelloWorldRouter from './v1/HelloWorldRouter';
@@ -15,6 +17,8 @@ import TrackingRouter from './v1/TrackingRouter';
 export default {
   AlertsRouter,
   AllStopsRouter,
+  ApplePlacesRouter,
+  AppleSearchRouter,
   DelayRouter,
   DocsRouter,
   HelloWorldRouter,

--- a/src/routers/v1/ApplePlacesRouter.js
+++ b/src/routers/v1/ApplePlacesRouter.js
@@ -1,0 +1,31 @@
+// @flow
+import type Request from 'express';
+import ApplicationRouter from '../../appdev/ApplicationRouter';
+import SearchUtils from '../../utils/SearchUtils';
+
+class ApplePlacesRouter extends ApplicationRouter<Object> {
+  constructor() {
+    super(['POST']);
+  }
+
+  getPath(): string {
+    return '/applePlaces/';
+  }
+
+  // eslint-disable-next-line require-await
+  async content(req: Request): Promise<any> {
+    if (
+      !req.body
+      || !req.body.query
+      || typeof req.body.query !== 'string'
+      || !req.body.places
+      || !Array.isArray(req.body.places)) {
+      return false;
+    }
+    const query = req.body.query.toLowerCase();
+    SearchUtils.updateCachedPredictionsForQuery(query, req.body.places);
+    return true;
+  }
+}
+
+export default new ApplePlacesRouter().router;

--- a/src/routers/v1/AppleSearchRouter.js
+++ b/src/routers/v1/AppleSearchRouter.js
@@ -1,0 +1,32 @@
+// @flow
+import type Request from 'express';
+import ApplicationRouter from '../../appdev/ApplicationRouter';
+import SearchUtils from '../../utils/SearchUtils';
+
+class AppleSearchRouter extends ApplicationRouter<Object> {
+  constructor() {
+    super(['POST']);
+  }
+
+  getPath(): string {
+    return '/appleSearch/';
+  }
+
+  async content(req: Request): Promise<any> {
+    if (!req.body || !req.body.query || typeof req.body.query !== 'string') {
+      return null;
+    }
+
+    const query = req.body.query.toLowerCase();
+    const cachedValue = SearchUtils.getCachedPredictionsForQuery(query);
+    const formattedStops = await SearchUtils.getFormattedStopsForQuery(query);
+
+    // Return the list of applePlaces and busStops
+    return {
+      applePlaces: cachedValue,
+      busStops: formattedStops,
+    };
+  }
+}
+
+export default new AppleSearchRouter().router;

--- a/src/routers/v1/SearchRouter.js
+++ b/src/routers/v1/SearchRouter.js
@@ -1,8 +1,6 @@
 // @flow
-import fuzz from 'fuzzball';
 import LRU from 'lru-cache';
 import type Request from 'express';
-import AllStopUtils from '../../utils/AllStopUtils';
 import ApplicationRouter from '../../appdev/ApplicationRouter';
 import RequestUtils from '../../utils/RequestUtils';
 import SearchUtils from '../../utils/SearchUtils';

--- a/src/routers/v1/SearchRouter.js
+++ b/src/routers/v1/SearchRouter.js
@@ -8,7 +8,6 @@ import RequestUtils from '../../utils/RequestUtils';
 import SearchUtils from '../../utils/SearchUtils';
 import Constants from '../../utils/Constants';
 
-const BUS_STOP = 'busStop';
 const queryToPredictionsCacheOptions = {
   max: 10000, // Maximum size of cache
   maxAge: 1000 * 60 * 60 * 24 * 5, // Maximum age in milliseconds
@@ -16,7 +15,6 @@ const queryToPredictionsCacheOptions = {
 const queryToPredictionsCache = LRU(queryToPredictionsCacheOptions);
 const GOOGLE_PLACE = 'googlePlace';
 const GOOGLE_PLACE_LOCATION = '42.4440,-76.5019';
-const MIN_FUZZ_RATIO = 75;
 
 class SearchRouter extends ApplicationRouter<Array<Object>> {
   constructor() {
@@ -35,21 +33,7 @@ class SearchRouter extends ApplicationRouter<Array<Object>> {
     const query = req.body.query.toLowerCase();
     const cachedValue = queryToPredictionsCache.get(query);
 
-    const allStops = await AllStopUtils.fetchAllStops();
-    const filteredStops = allStops.filter(s => (
-      fuzz.partial_ratio(s.name.toLowerCase(), query) >= MIN_FUZZ_RATIO
-    ));
-    filteredStops.sort((a, b) => {
-      const aPartialRatio = fuzz.partial_ratio(query, a.name.toLowerCase());
-      const bPartialRatio = fuzz.partial_ratio(query, b.name.toLowerCase());
-      return bPartialRatio - aPartialRatio;
-    });
-    const formattedStops = filteredStops.map(s => ({
-      type: BUS_STOP,
-      lat: s.lat,
-      long: s.long,
-      name: s.name,
-    }));
+    const formattedStops = await SearchUtils.getFormattedStopsForQuery(query);
 
     // Return the list of googlePlaces and busStops
     if (cachedValue) return cachedValue.concat(formattedStops);

--- a/src/utils/SearchUtils.js
+++ b/src/utils/SearchUtils.js
@@ -1,12 +1,21 @@
 // @flow
+import fuzz from 'fuzzball';
 import LRU from 'lru-cache';
+import AllStopUtils from './AllStopUtils';
 import RequestUtils from './RequestUtils';
 import Constants from './Constants';
 
+const BUS_STOP = 'busStop';
+const MIN_FUZZ_RATIO = 75;
 const placeIDToCoordsCacheOptions = {
   max: 10000, // Maximum size of cache
 };
 const placeIDToCoordsCache = LRU(placeIDToCoordsCacheOptions);
+const queryToPredictionsCacheOptions = {
+  max: 10000, // Maximum size of cache
+  maxAge: 1000 * 60 * 60 * 24 * 5, // Maximum age in milliseconds
+};
+const queryToPredictionsCache = LRU(queryToPredictionsCacheOptions);
 
 async function getCoordsForPlaceID(placeID: String): Object {
   const cachedValue = placeIDToCoordsCache.get(placeID);
@@ -42,6 +51,36 @@ async function getCoordsForPlaceID(placeID: String): Object {
   };
 }
 
+async function getFormattedStopsForQuery(query: String): Promise<Array<Object>> {
+  const allStops = await AllStopUtils.fetchAllStops();
+  const filteredStops = allStops.filter(s => (
+    fuzz.partial_ratio(s.name.toLowerCase(), query) >= MIN_FUZZ_RATIO
+  ));
+  filteredStops.sort((a, b) => {
+    const aPartialRatio = fuzz.partial_ratio(query, a.name.toLowerCase());
+    const bPartialRatio = fuzz.partial_ratio(query, b.name.toLowerCase());
+    return bPartialRatio - aPartialRatio;
+  });
+  const formattedStops = filteredStops.map(s => ({
+    type: BUS_STOP,
+    lat: s.lat,
+    long: s.long,
+    name: s.name,
+  }));
+  return formattedStops;
+}
+
+function getCachedPredictionsForQuery(query: string): ?Array<Object> {
+  return queryToPredictionsCache.get(query);
+}
+
+function updateCachedPredictionsForQuery(query: String, places: Array<Object>): void {
+  queryToPredictionsCache.set(query, places);
+}
+
 export default {
+  getCachedPredictionsForQuery,
   getCoordsForPlaceID,
+  getFormattedStopsForQuery,
+  updateCachedPredictionsForQuery,
 };


### PR DESCRIPTION
To convert from using GooglePlaces API to using Apple's FREE MapKit, here is my current plan:

When a user makes a search on iOS for a query, i.e. `Duff`, client will hit `/appleSearch` which will return an array of `busStops` AND an array of `applePlaces` if those places exist in our cache. If it doesn't, we just return an array of `busStops`. On client-side, when we see that server did not return any `applePlaces`, we will do the lookup for ApplePlaces and then send that array of `applePlaces` to `/applePlaces` which will just store these places in the cache. Now, the next time a user types in `Duff`, server will just return both the `busStops` and `applePlaces` and client will not need to do the lookup for ApplePlaces.

This PR accomplishes this plan by creating an `AppleSearchRouter` and `ApplePlacesRouter`. I'm honestly not sure what the best names for these two were so suggestions are appreciated!