### PR TITLE
Add delay and stayOnBusForTransfer fields for complete v2/route responses

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - /usr/src/app/node_modules
 
   ghopper:
-    image: cornellappdev/transit-ghopper:v1.0.0
+    image: cornellappdev/transit-ghopper:v1.0.2
     ports:
       - "8988:8988"
 
@@ -28,7 +28,7 @@ services:
       - "8987:8987"
 
   live-tracking:
-    image: cornellappdev/transit-python:v1.0.0
+    image: cornellappdev/transit-python:v1.0.2
     env_file: python.envrc
     ports:
       - "5000:5000"

--- a/src/utils/ParseRouteUtils.js
+++ b/src/utils/ParseRouteUtils.js
@@ -1,6 +1,7 @@
 // @flow
 import createGpx from 'gps-to-gpx';
 
+import { isNullOrUndefined } from 'util';
 import { MAP_MATCHING } from './EnvUtils';
 import AllStopUtils from './AllStopUtils';
 import GTFSUtils from './GTFSUtils';
@@ -65,7 +66,25 @@ function mergeDirections(first, second): Object {
   const stops = first.stops.concat(second.stops);
   const tripIDs = first.tripIdentifiers.concat(second.tripIdentifiers);
 
+  // The combined delay is only the first bus route's delay, because that is
+  // how much the combined route is initially delayed by and is what the user
+  // needs to know in order to board the route on time.
+  const delay = isNullOrUndefined(first.delay) ? null : first.delay;
+
+  // If there is any part of the bus route that a passenger does not stay on for
+  // transfer, then the passenger has to get off the bus at some point, so
+  // stayOnBusForTransfer is false if either route's stayOnBusForTransfer is false.
+  const firstStayOnBusForTransfer = isNullOrUndefined(
+    first.stayOnBusForTransfer,
+  ) ? false : first.stayOnBusForTransfer;
+  const secondStayOnBusForTransfer = isNullOrUndefined(
+    second.stayOnBusForTransfer,
+  ) ? false : second.stayOnBusForTransfer;
+  const stayOnBusForTransfer = firstStayOnBusForTransfer
+    && secondStayOnBusForTransfer;
+
   return {
+    delay,
     distance,
     endLocation: second.endLocation,
     endTime: second.endTime,
@@ -74,6 +93,7 @@ function mergeDirections(first, second): Object {
     routeNumber: first.routeNumber,
     startLocation: first.startLocation,
     startTime: first.startTime,
+    stayOnBusForTransfer,
     stops,
     tripIdentifiers: tripIDs,
     type: first.type,


### PR DESCRIPTION
# The issue
#264 Right now, we don't always return `delay` or `stayOnBusForTransfer` in our `directions` list that's returned by `v2\route`, which causes issues for iOS and is the reason for why the app shows a `could not fetch routes` error for only certain stops:

## Before
![image](https://user-images.githubusercontent.com/13739525/65841437-345c3f80-e2f0-11e9-909b-f391454e0195.png)

## After
![image](https://user-images.githubusercontent.com/13739525/65841446-40480180-e2f0-11e9-9885-b9b9494e3447.png)

# The fix
Thanks to @kevinchan159, I found that `mergeDirections` in `parseRouteUtils.js` was missing some fields (`delay` and `stayOnBusForTransfer`!) when it was merging routes, so I added the fields in with logic that:
1.  the combined delay is only the first bus route's delay, because that's how much the combined route is initially delayed by and is what the user needs to know in order to board the route on time
2. the combined `stayOnBusForTransfer` is only true if both routes' `stayOnBusForTransfer`s are true -- if you have to get off the bus at any point in time, the whole route's `stayOnBusForTransfer` is false! I could also get feedback on this since I only concluded this logically

# Validating the fix
Here's the before and after of our backend responses:
<img width="1236" alt="Screen Shot 2019-09-29 at 7 31 22 PM" src="https://user-images.githubusercontent.com/13739525/65841522-370b6480-e2f1-11e9-9ea4-f99b7d735f04.png">
<img width="1258" alt="Screen Shot 2019-09-29 at 7 31 29 PM" src="https://user-images.githubusercontent.com/13739525/65841523-383c9180-e2f1-11e9-9738-0b30c4ad65a2.png">

I've also tested this on `transit-dev` (`transit-dev:missing-keys`) with `Transit Beta 1.6.2 (6)` and I ran `integration` locally and got 21/21 tests pass :) 

# Another update
I also updated the `docker-compose.yml` because the new tags are required in order to run this PR locally.

