### PR TITLE
Add new /delays endpoint for easier iOS handling of live tracking

### DIFF
--- a/src/API.js
+++ b/src/API.js
@@ -20,6 +20,7 @@ class API extends ApplicationAPI {
       Routers.ApplePlacesRouter,
       Routers.AppleSearchRouter,
       Routers.DelayRouter,
+      Routers.DelaysRouter,
       Routers.HelloWorldRouter,
       Routers.MultiRouteRouter,
       Routers.PlacesAutocompleteRouter,

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -3,6 +3,7 @@ import AllStopsRouter from './v1/AllStopsRouter';
 import ApplePlacesRouter from './v1/ApplePlacesRouter';
 import AppleSearchRouter from './v1/AppleSearchRouter';
 import DelayRouter from './v1/DelayRouter';
+import DelaysRouter from './v2/DelaysRouter';
 import DocsRouter from './DocsRouter';
 import HelloWorldRouter from './v1/HelloWorldRouter';
 import MultiRouteRouter from './v1/MultiRouteRouter';
@@ -20,6 +21,7 @@ export default {
   ApplePlacesRouter,
   AppleSearchRouter,
   DelayRouter,
+  DelaysRouter,
   DocsRouter,
   HelloWorldRouter,
   MultiRouteRouter,

--- a/src/routers/v2/DelaysRouter.js
+++ b/src/routers/v2/DelaysRouter.js
@@ -1,0 +1,30 @@
+// @flow
+import ApplicationRouter from '../../appdev/ApplicationRouter';
+import RealtimeFeedUtils from '../../utils/RealtimeFeedUtils';
+
+class DelaysRouter extends ApplicationRouter<Object> {
+  constructor() {
+    super(['POST']);
+  }
+
+  getPath(): string {
+    return '/delays/';
+  }
+
+  async content(req): Promise<any> {
+    const rtf = await RealtimeFeedUtils.fetchRTF();
+    const delays = req.body.data.map(async ({ stopID, tripID }) => {
+      const res = await RealtimeFeedUtils.getDelayInformation(
+        stopID, tripID, rtf,
+      );
+      return {
+        stopID,
+        tripID,
+        delay: res ? res.delay : null,
+      };
+    });
+    return Promise.all(delays);
+  }
+}
+
+export default new DelaysRouter().router;


### PR DESCRIPTION
#262 

Right now iOS has to make a request for each route's delay, so now a DelaysRouter exists such that it can take in multiple tripID and stopIDs to get multiple delays:

<img width="472" alt="Screen Shot 2019-10-05 at 1 02 28 AM" src="https://user-images.githubusercontent.com/13739525/66250105-fefa8c00-e70b-11e9-93eb-b5685e97f649.png">
