### PR TITLE
Update image tags in local docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - /usr/src/app/node_modules
 
   ghopper:
-    image: cornellappdev/transit-ghopper:v1.0.2
+    image: cornellappdev/transit-ghopper:v1.0.7
     ports:
       - "8988:8988"
 
@@ -28,7 +28,7 @@ services:
       - "8987:8987"
 
   live-tracking:
-    image: cornellappdev/transit-python:v1.0.2
+    image: cornellappdev/transit-python:v1.0.7
     env_file: python.envrc
     ports:
       - "5000:5000"


### PR DESCRIPTION
## Overview

Master does not run locally due to Manish's changes. So, I am reverting it (in my other PR #273) and also updating our image tags so that it can be run!


## Changes Made

Update image tags in docker-compose.yml so that when you run locally you can get the up-to-date routes (have the current GTFS data).


## Next Steps 

Manish will put in a new PR to fix his change!


