### PR TITLE
Readjust walking route departure and arrival time due to bus buffer time

### DIFF
--- a/src/utils/RouteUtils.js
+++ b/src/utils/RouteUtils.js
@@ -153,7 +153,10 @@ async function getParsedWalkingAndBusRoutes(
     };
   }
 
-  const parsedRoutes = await ParseRouteUtils.parseRoutes(routes, originName, destinationName);
+  const departureTimeMs = GraphhopperUtils.getDepartureTime(departureTimeQuery, isArriveBy, 0);
+  const parsedRoutes = await ParseRouteUtils.parseRoutes(
+    routes, originName, destinationName, departureTimeMs, isArriveBy,
+  );
   let parsedWalkingRoute = parsedRoutes.find(route => route.numberOfTransfers === -1);
 
   // Make request to Ghopper walking service if the bus service doesn't provide walking directions


### PR DESCRIPTION
## Overview
Right now, there are two cases in which we display a walking route (note that we always show a walking route), and here are screenshots of this tragic issue we've been having with walking times:
### 1. A walking route we get solely from Graphhopper walking (when there are no other bus routes)
Here you can notice that the start time should actually be 11:56!
<img src="https://user-images.githubusercontent.com/13739525/68073643-a77e2900-fd68-11e9-8ddf-bc815de7b450.png" height="50%" width="50%"/>

### 2. A walking route that we get from Graphhopper bus, which involves stuffing in a bus buffer time (a trick that we've been using so that we get more routes around the time that the client sends)
Once again, the start time should actually be 11:56!
<img src="https://user-images.githubusercontent.com/13739525/68073657-c5e42480-fd68-11e9-98d2-b3487cba2bb6.png" height="50%" width="50%" />

## Changes Made
There are a lot of entry points that I found that I could modify the bus routes. The way that I found that was most intuitive was in `ParseRouteUtils`. In `RouteUtils`, we first fetch routes with `GraphhopperUtils`, and then we parse them with `parseRoute` in `parseRouteUtils`. I thought that I should leave fetching to `GraphhopperUtils` and modifying the routes in `parseRouteUtils` since we have similar logic in there. What I did was check if the `route.transfers` attribute was equal to `-1` (which means it is a walking route), and just overwrite its departure and arrival times in both the walking route and the walking route's `direction`'s array (direction's start and end times) -- since we really don't know which bus buffer time (could be 20 min or 40 min difference) that was used to fetch the routes, as there's some complex logic used to merge bus routes afterwards.

I also refactored `parseWalkingRoute` to match my changes above so that other people know that these are exactly the same things getting modified -- it should be `time` and not `date` in the names we're using because the client is getting these with the keys named as `arrivalTime` and `departureTime`, not `arrivalDate` and `departureDate`!

### Now that everything's fixed, here's how it looks on the dev server:
### 1. A lone walking route
<img src="https://user-images.githubusercontent.com/13739525/68073750-d6e16580-fd69-11e9-8a9b-ef5277c7274d.png" height="50%" width="50%" />

### 2. A walking route with other bus routes
<img src="https://user-images.githubusercontent.com/13739525/68073743-c4ffc280-fd69-11e9-9c23-81d6622001fb.png" height="50%" width="50%" />

### 3. A walking route with arriveBy as true
<img src="https://user-images.githubusercontent.com/13739525/68073757-e8c30880-fd69-11e9-8902-a2f5e0be0536.png" height="50%" width="50%" />


## Test Coverage
Pushed onto the dev server as of 11/2 noon, and everything looks fine just by going through the beta app. Will have it sit for a while and see if integration picks up anything funky -- but integration isn't testing this to begin with so I'm doubtful that this is necessary.

## Next Steps 
Going to talk to integration about testing departure and arrival times on walking routes.

## Related PRs or Issues 
Resolves Issue #261 

