### PR TITLE
Fix "promise chaining cycle" due to modifying promises in walking route

### DIFF
--- a/src/utils/GraphhopperUtils.js
+++ b/src/utils/GraphhopperUtils.js
@@ -200,7 +200,7 @@ function getValidBusRoutes(busRoutes: Array<Object>, busRoutesToCheck: Array<Obj
  * @returns {Array<Object>}
  */
 async function fetchRoutes(end: string, start: string, departureTimeDateNow: string,
-  isArriveByQuery: boolean): Array<Object> {
+  isArriveByQuery: boolean): Promise<Array<Object>> {
   let routes;
 
   const sharedOptions = { method: 'GET', qsStringifyOptions: { arrayFormat: 'repeat' } };

--- a/src/utils/ParseRouteUtils.js
+++ b/src/utils/ParseRouteUtils.js
@@ -460,8 +460,8 @@ function parseRoutes(
   originalDepartureTimeMs: number,
   isArriveByQuery: boolean,
 ): Promise<Array<Object>> {
-  return Promise.all(busRoutes.map(async (busRoute) => {
-    try {
+  try {
+    return Promise.all(busRoutes.map(async (busRoute) => {
       // array containing legs of journey. e.g. walk, bus ride, walk
       const { legs } = busRoute;
       const numberOfLegs = legs.length;
@@ -694,12 +694,12 @@ function parseRoutes(
         totalDuration,
         travelDistance,
       };
-    } catch (error) {
-      throw new Error(
-        LogUtils.logErr(error, busRoutes.length, 'Parse final route failed'),
-      );
-    }
-  }));
+    }));
+  } catch (error) {
+    throw new Error(
+      LogUtils.logErr(error, busRoutes.length, 'Parse final route failed'),
+    );
+  }
 }
 
 export default {

--- a/src/utils/ParseRouteUtils.js
+++ b/src/utils/ParseRouteUtils.js
@@ -676,14 +676,17 @@ function parseRoutes(
         const walkDepartureTime = convertMillisecondsToISOString(startTimeMs);
         const walkArrivalTime = convertMillisecondsToISOString(endTimeMs);
 
-        directions[0].startTime = walkDepartureTime;
-        directions[0].endTime = walkArrivalTime;
+        const walkDirections = {
+          ...directions[0],
+          startTime: walkDepartureTime,
+          endTime: walkArrivalTime,
+        };
 
         return {
           arrivalTime: walkArrivalTime,
           boundingBox,
           departureTime: walkDepartureTime,
-          directions,
+          directions: [walkDirections],
           endCoords,
           endName: destinationName,
           numberOfTransfers: busRoute.transfers,


### PR DESCRIPTION
# UPDATE: looks like this change doesn't actually fix anything -- I'm going to leave this PR open as I'm figuring this out and add stuff as I go :'(


## Overview
So right now, my walking route time fix is extremely flakey because there's this promise cycle detection error, and I finally figured out what the issue is. And it's because I've been directly modifying the `directions` array that's a promise!


## Changes Made
So instead of directly modifying the `directions`'s first element's `startTime` and `endTime`, I created a new directions and appended the rest of the existing information so that I don't mess with all of this asynchronous jazz.

I've also renamed the return types to `Promise`s because this should be fixed eventually.


## Test Coverage
Currently deployed on dev and doesn't break anything. I'll let it sit for a while and then merge this PR in. 


## Next Steps
I think I will write a Python script that checks for a valid `ithaca-transit-backend` JSON response -- because I think that would have been super helpful for me to use than to manually cross check with our documentation. Or I think I might talk to someone about adding this to `integration`.


## Related PRs or Issues 
#274 This was the culprit PR that had the promise cycle detection issue.
#261 Actually addresses this issue finally.

