### PR TITLE
Modify v1/search to use the same cache as v2/search

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - /usr/src/app/node_modules
 
   ghopper:
-    image: cornellappdev/transit-ghopper:v1.0.7
+    image: cornellappdev/transit-ghopper:v1.1.6
     ports:
       - "8988:8988"
 
@@ -28,7 +28,7 @@ services:
       - "8987:8987"
 
   live-tracking:
-    image: cornellappdev/transit-python:v1.0.7
+    image: cornellappdev/transit-python:v1.1.6
     env_file: python.envrc
     ports:
       - "5000:5000"

--- a/src/routers/v1/SearchRouter.js
+++ b/src/routers/v1/SearchRouter.js
@@ -1,16 +1,16 @@
 // @flow
-import LRU from 'lru-cache';
+// import LRU from 'lru-cache';
 import type Request from 'express';
 import ApplicationRouter from '../../appdev/ApplicationRouter';
 import RequestUtils from '../../utils/RequestUtils';
 import SearchUtils from '../../utils/SearchUtils';
 import Constants from '../../utils/Constants';
 
-const queryToPredictionsCacheOptions = {
-  max: 10000, // Maximum size of cache
-  maxAge: 1000 * 60 * 60 * 24 * 5, // Maximum age in milliseconds
-};
-const queryToPredictionsCache = LRU(queryToPredictionsCacheOptions);
+// const queryToPredictionsCacheOptions = {
+//   max: 10000, // Maximum size of cache
+//   maxAge: 1000 * 60 * 60 * 24 * 5, // Maximum age in milliseconds
+// };
+// const queryToPredictionsCache = LRU(queryToPredictionsCacheOptions);
 const GOOGLE_PLACE = 'googlePlace';
 const GOOGLE_PLACE_LOCATION = '42.4440,-76.5019';
 
@@ -29,7 +29,7 @@ class SearchRouter extends ApplicationRouter<Array<Object>> {
     }
 
     const query = req.body.query.toLowerCase();
-    const cachedValue = queryToPredictionsCache.get(query);
+    const cachedValue = SearchUtils.queryToPredictionsCache.get(query);
 
     const formattedStops = await SearchUtils.getFormattedStopsForQuery(query);
 
@@ -70,7 +70,7 @@ class SearchRouter extends ApplicationRouter<Array<Object>> {
 
       if (googlePredictions) {
         const filteredPredictions = getFilteredPredictions(googlePredictions, formattedStops);
-        queryToPredictionsCache.set(query, filteredPredictions);
+        SearchUtils.queryToPredictionsCache.set(query, filteredPredictions);
         return filteredPredictions.concat(formattedStops);
       }
     }

--- a/src/routers/v1/SearchRouter.js
+++ b/src/routers/v1/SearchRouter.js
@@ -1,16 +1,9 @@
-// @flow
-// import LRU from 'lru-cache';
 import type Request from 'express';
 import ApplicationRouter from '../../appdev/ApplicationRouter';
 import RequestUtils from '../../utils/RequestUtils';
 import SearchUtils from '../../utils/SearchUtils';
 import Constants from '../../utils/Constants';
 
-// const queryToPredictionsCacheOptions = {
-//   max: 10000, // Maximum size of cache
-//   maxAge: 1000 * 60 * 60 * 24 * 5, // Maximum age in milliseconds
-// };
-// const queryToPredictionsCache = LRU(queryToPredictionsCacheOptions);
 const GOOGLE_PLACE = 'googlePlace';
 const GOOGLE_PLACE_LOCATION = '42.4440,-76.5019';
 


### PR DESCRIPTION
## Overview
We're still incurring some costs from Google Places API (very minor but still non-zero). This is probably because not everyone has updated the iOS app to the newest version which hits the AppleSearchRouter  which means that some users are still hitting the old v1 Search Router which currently has its own separate cache. (Thanks @kevinchan159 for the easy explanation to copy)

## Changes Made
This change converts our v1 SearchRouter to use the same cache as the one in the AppleSearchRouter and it’ll help us cut some costs because a majority of our users are hitting the AppleSearchRouter anyway since they have updated. Also updated the `docker-compose.yml` to help things run locally as of the GTFS data now.

## Test Coverage
Tested this locally and it works. Will let this sit on the dev server for a bit before merging to master and deploying to production.

## Next Steps 
Depending on if this actually cuts costs or not, I'll do some more investigation.

