### PR TITLE
Remove bus routes with an earlier start time than departure time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - /usr/src/app/node_modules
 
   ghopper:
-    image: cornellappdev/transit-ghopper:v1.1.6
+    image: cornellappdev/transit-ghopper:v1.1.8
     ports:
       - "8988:8988"
 
@@ -28,7 +28,7 @@ services:
       - "8987:8987"
 
   live-tracking:
-    image: cornellappdev/transit-python:v1.1.6
+    image: cornellappdev/transit-python:v1.1.8
     env_file: python.envrc
     ports:
       - "5000:5000"

--- a/src/utils/ParseRouteUtils.js
+++ b/src/utils/ParseRouteUtils.js
@@ -183,6 +183,12 @@ async function condenseRoute(
       if (startTime < departureTimeNowMs - ONE_MIN_IN_MS - delayMs) {
         return null;
       }
+
+      // Temporary fix to prevent bus routes starting before departure time from
+      // being returned.
+      if (startTime < departureTimeNowMs) {
+        return null;
+      }
     }
 
     if (previousDirection


### PR DESCRIPTION
## Overview
Right now, we show routes that are some 20-30 minutes before the departure time, be it arrive by or not.

I still need to investigate why this is happening, but for now I've put in a trivial fix so that our app doesn't look weird.

![image](https://user-images.githubusercontent.com/13739525/73891903-5b4cf400-4843-11ea-8c8f-d40e4b34b4d2.png)


## Changes Made
Trash the bus route if it's before the time that the user expects the leave when we parse bus routes.


## Test Coverage
Tested locally and on the dev server under `transit-dev:alanna`.


## Next Steps
Will actually investigate what's going on and fix the early routes. 
Also, an issue with this change is that if there's some walking time before the bus route, it may still be earlier than the departure time. 

## Related PRs or Issues
#284 
