### PR TITLE
Fix delay NaN handling that leaves early routes going undetected

### DIFF
--- a/src/utils/ParseRouteUtils.js
+++ b/src/utils/ParseRouteUtils.js
@@ -179,14 +179,9 @@ async function condenseRoute(
      * the route even if the start time is earlier than the current time.
      */
     if (departureDelayBuffer && direction.type === DIRECTION_TYPE.DEPART) {
-      const delayMs = direction.delay !== null ? direction.delay * 1000 : 0;
+      // direction.delay could be undefined, NaN, or null
+      const delayMs = direction.delay ? direction.delay * 1000 : 0;
       if (startTime < departureTimeNowMs - ONE_MIN_IN_MS - delayMs) {
-        return null;
-      }
-
-      // Temporary fix to prevent bus routes starting before departure time from
-      // being returned.
-      if (startTime < departureTimeNowMs) {
         return null;
       }
     }


### PR DESCRIPTION
## Overview 
Earlier I had made a PR trying to get rid of early bus routes, but that was just a temp fix. Did some digging today and found out that delayMs was NaN!

## Changes Made
So the issue is that `direction.delay` is only checked if it is not `null`, but it could be `NaN`. Found this out thanks to [a very helpful Stack Overflow post](https://stackoverflow.com/questions/5515310/is-there-a-standard-function-to-check-for-null-undefined-or-blank-variables-in) about null values in JavaScript:
```
if( value ) {
}
```
will evaluate to true if value is not:

```
null
undefined
NaN
empty string ("")
0
false
```
So, all I did was check if `direction.delay` was true or not.

## Test Coverage
Works locally and also works deployed as `transit-dev:alanna` on the dev server as of right now.

## Next Steps 
We are done with this finally!


## Related PRs or Issues
#285 
#284 
