### PR TITLE
Refactor `/tracking` to make requests to the microservice and return valid vehicle info

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - /usr/src/app/node_modules
 
   ghopper:
-    image: cornellappdev/transit-ghopper:v1.1.8
+    image: cornellappdev/transit-ghopper:v1.2.1
     ports:
       - "8988:8988"
 
@@ -28,7 +28,7 @@ services:
       - "8987:8987"
 
   live-tracking:
-    image: cornellappdev/transit-python:v1.1.8
+    image: cornellappdev/transit-python:alanna
     env_file: python.envrc
     ports:
       - "5000:5000"

--- a/src/routers/v1/TrackingRouter.js
+++ b/src/routers/v1/TrackingRouter.js
@@ -14,7 +14,6 @@ class TrackingRouter extends ApplicationRouter<Object> {
   // eslint-disable-next-line require-await
   async content(req): Promise<any> {
     if (!req.body || !req.body.data || !req.body.data.length || req.body.data.length === 0) {
-      console.log('req.body:', req.body);
       return {
         case: 'invalidRequest',
       };

--- a/src/routers/v1/TrackingRouter.js
+++ b/src/routers/v1/TrackingRouter.js
@@ -14,6 +14,7 @@ class TrackingRouter extends ApplicationRouter<Object> {
   // eslint-disable-next-line require-await
   async content(req): Promise<any> {
     if (!req.body || !req.body.data || !req.body.data.length || req.body.data.length === 0) {
+      console.log('req.body:', req.body);
       return {
         case: 'invalidRequest',
       };

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -36,21 +36,19 @@ async function fetchVehicles(): Object {
  */
 async function getTrackingResponse(requestData: Object): Object {
   LogUtils.log({ message: 'getTrackingResponse: entering function' });
-  const trackingInformation = [];
   const vehicles = await fetchVehicles();
+  console.log('vehicles', vehicles);
 
-  // for each input
-  await Promise.all(requestData.map((data) => {
+  const trackingInformation = requestData.map((data) => {
     const { routeID, tripID } = data;
     const vehicleData = getVehicleInformation(routeID, tripID, vehicles);
-
     if (!vehicleData) {
       LogUtils.log({ message: 'getVehicleResponse: noData', vehicleData });
-      return false;
+      return null;
     }
-    trackingInformation.push(vehicleData);
-    return true;
-  }));
+    return vehicleData;
+  }).filter(Boolean);
+
   return trackingInformation;
 }
 
@@ -61,7 +59,11 @@ async function getTrackingResponse(requestData: Object): Object {
  * @param rtf
  * @returns Object
  */
-function getDelayInformation(stopID: String, tripID: String, rtf: Object): ?Object {
+function getDelayInformation(
+  stopID: ?String,
+  tripID: ?String,
+  rtf: ?Object,
+): ?Object {
   // rtf param ensures the realtimeFeed doesn't update in the middle of execution
   // if invalid params or the trip is inactive
   if (!stopID
@@ -88,10 +90,10 @@ function getDelayInformation(stopID: String, tripID: String, rtf: Object): ?Obje
 }
 
 function getVehicleInformation(
-  routeID: String,
-  tripID: String,
-  vehicles: Object,
-): ?Array<Object> {
+  routeID: ?String,
+  tripID: ?String,
+  vehicles: ?Object,
+): ?Object {
   // vehicles param ensures the vehicle tracking information doesn't update in
   // the middle of execution
   if (!routeID
@@ -105,9 +107,8 @@ function getVehicleInformation(
     });
     return null;
   }
-  return Object.values(vehicles).filter(
-    v => v.routeID === routeID && v.tripID === tripID,
-  )[0];
+
+  return Object.values(vehicles).find(v => v.routeID === routeID && v.tripID === tripID);
 }
 
 export default {

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -14,13 +14,11 @@ async function fetchRTF(): Object {
 }
 
 async function fetchVehicles(): Object {
-  console.log('fetching vehicles');
   const options = {
     ...Constants.GET_OPTIONS,
     url: `http://${PYTHON_APP || 'localhost'}:5000/vehicles`,
   };
   const data = await RequestUtils.createRequest(options, 'Vehicles request failed');
-  console.log('data:', data);
   return JSON.parse(data);
 }
 
@@ -93,7 +91,7 @@ function getVehicleInformation(
   routeID: String,
   tripID: String,
   vehicles: Object,
-): ?Object {
+): ?Array<Object> {
   // vehicles param ensures the vehicle tracking information doesn't update in
   // the middle of execution
   if (!routeID
@@ -107,16 +105,9 @@ function getVehicleInformation(
     });
     return null;
   }
-  const vehicleData = {};
-  console.log('VEHICLES:', vehicles);
-
-  // vehicles.forEach((vehicle) => {
-  //   console.log('vehicle is:', vehicle);
-  //   if (vehicle.routeID === routeID && vehicle.tripID === tripID) {
-  //     vehicleData.id = vehicle.id;
-  //   }
-  // });
-  return vehicleData;
+  return Object.values(vehicles).filter(
+    v => v.routeID === routeID && v.tripID === tripID,
+  )[0];
 }
 
 export default {

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -3,140 +3,57 @@ import { PYTHON_APP } from './EnvUtils';
 import Constants from './Constants';
 import LogUtils from './LogUtils';
 import RequestUtils from './RequestUtils';
-import TokenUtils from './TokenUtils';
 
 async function fetchRTF(): Object {
   const options = {
     ...Constants.GET_OPTIONS,
     url: `http://${PYTHON_APP || 'localhost'}:5000/rtf`,
   };
-  const data = await RequestUtils.createRequest(options, 'Tracking request failed');
+  const data = await RequestUtils.createRequest(options, 'RTF request failed');
+  return JSON.parse(data);
+}
+
+async function fetchVehicles(): Object {
+  console.log('fetching vehicles');
+  const options = {
+    ...Constants.GET_OPTIONS,
+    url: `http://${PYTHON_APP || 'localhost'}:5000/vehicles`,
+  };
+  const data = await RequestUtils.createRequest(options, 'Vehicles request failed');
+  console.log('data:', data);
   return JSON.parse(data);
 }
 
 /**
- * Given an array of { stopID, routeID, [tripID] },
- * Return bus and tracking data including location
+ * Given an array of { routeID, tripID },
+ * Return bus information
  * Input:
  [
  {
-   “stopID” : String,
    “routeID” : String,
-   “tripIdentifiers” : [String]
+   tripID : String
  },
  …
  ]
  */
 async function getTrackingResponse(requestData: Object): Object {
   LogUtils.log({ message: 'getTrackingResponse: entering function' });
-
   const trackingInformation = [];
-  const rtf = await fetchRTF(); // ensures the realtimeFeed doesn't update in the middle of execution
+  const vehicles = await fetchVehicles();
 
   // for each input
-  await Promise.all(requestData.map(async (data): Promise<boolean> => {
-    const { stopID, routeID, tripIdentifiers } = data;
-    const realtimeDelayData = getDelayInformation(stopID, tripIdentifiers[0], rtf);
+  await Promise.all(requestData.map((data) => {
+    const { routeID, tripID } = data;
+    const vehicleData = getVehicleInformation(routeID, tripID, vehicles);
 
-    if (realtimeDelayData) {
-      const authHeader = await TokenUtils.fetchAuthHeader();
-      const options = {
-        method: 'GET',
-        url: 'https://gateway.api.cloud.wso2.com:443/t/mystop/tcat/v1/rest/Vehicles/GetAllVehiclesForRoute',
-        headers: {
-          Authorization: authHeader,
-          'Cache-Control': 'no-cache',
-          'Postman-Token': 'b688b636-87ea-4e04-9f3e-ba34e811e639',
-        },
-        qs: { routeID },
-      };
-
-      const trackingRequest = await RequestUtils.createRequest(options, 'Tracking request failed');
-      if (!trackingRequest) return false;
-
-      /**
-       * Parse request to object and map valid realtime data to info for each bus
-       */
-      const busFound = JSON.parse(trackingRequest) // parse the request
-        .find( // find the first tracking data matching the vehicleId
-          busInfo => busInfo.VehicleId === realtimeDelayData.vehicleId,
-        );
-
-      if (!busFound) return false;
-
-      const trackingData = ((busInfo) => { // create object and return
-        let lastUpdated = busInfo.LastUpdated;
-        const firstParan = lastUpdated.indexOf('(') + 1;
-        const secondParan = lastUpdated.indexOf('-');
-        lastUpdated = parseInt(lastUpdated.slice(firstParan, secondParan));
-        return {
-          case: 'validData',
-          commStatus: busInfo.CommStatus,
-          delay: realtimeDelayData.delay,
-          destination: busInfo.Destination,
-          deviation: busInfo.Deviation,
-          direction: busInfo.Direction,
-          displayStatus: busInfo.DisplayStatus,
-          gpsStatus: busInfo.GPSStatus,
-          heading: busInfo.Heading,
-          lastStop: busInfo.LastStop,
-          lastUpdated,
-          latitude: busInfo.Latitude,
-          longitude: busInfo.Longitude,
-          name: busInfo.Name,
-          opStatus: busInfo.OpStatus,
-          routeID: busInfo.RouteId,
-          runID: busInfo.RunId,
-          speed: busInfo.Speed,
-          tripID: busInfo.TripId,
-          vehicleID: busInfo.VehicleId,
-        };
-      })(busFound);
-
-      LogUtils.log({ message: 'getTrackingResponse: validData', trackingData });
-
-      // we have tracking data for the bus
-      if (trackingData) {
-        trackingInformation.push(trackingData);
-      } else {
-        return false;
-      }
-      return true;
+    if (!vehicleData) {
+      LogUtils.log({ message: 'getVehicleResponse: noData', vehicleData });
+      return false;
     }
-    return false;
-  })).catch((err) => {
-    LogUtils.logErr(err, requestData, 'Tracking error');
-    throw err;
-  });
-
-  if (trackingInformation.length > 0) {
-    return trackingInformation;
-  }
-
-  LogUtils.log({ message: 'getTrackingResponse: noData', trackingInformation });
-  // TODO: change this to non-dummy data once client fix is out
-  return [{
-    case: 'noData',
-    commStatus: '',
-    delay: 0,
-    destination: '',
-    deviation: 0,
-    direction: '',
-    displayStatus: '',
-    gpsStatus: 0,
-    heading: 0,
-    lastStop: '',
-    lastUpdated: 0,
-    latitude: 0,
-    longitude: 0,
-    name: '',
-    opStatus: '',
-    routeID: parseInt(requestData[0].routeID),
-    runID: 0,
-    speed: 0,
-    tripID: 0,
-    vehicleID: 0,
-  }];
+    trackingInformation.push(vehicleData);
+    return true;
+  }));
+  return trackingInformation;
 }
 
 /**
@@ -172,8 +89,40 @@ function getDelayInformation(stopID: String, tripID: String, rtf: Object): ?Obje
   };
 }
 
+function getVehicleInformation(
+  routeID: String,
+  tripID: String,
+  vehicles: Object,
+): ?Object {
+  // vehicles param ensures the vehicle tracking information doesn't update in
+  // the middle of execution
+  if (!routeID
+    || !tripID
+    || !vehicles
+    || vehicles === {}) {
+    LogUtils.log({
+      category: 'getVehicleInformation NULL',
+      routeID,
+      tripID,
+    });
+    return null;
+  }
+  const vehicleData = {};
+  console.log('VEHICLES:', vehicles);
+
+  // vehicles.forEach((vehicle) => {
+  //   console.log('vehicle is:', vehicle);
+  //   if (vehicle.routeID === routeID && vehicle.tripID === tripID) {
+  //     vehicleData.id = vehicle.id;
+  //   }
+  // });
+  return vehicleData;
+}
+
 export default {
   fetchRTF,
+  fetchVehicles,
   getDelayInformation,
+  getVehicleInformation,
   getTrackingResponse,
 };


### PR DESCRIPTION
Again, sorry if I added too many reviewers, everyone goes MIA on me so I wanted to spam as many people as possible. Please help me get this approved ASAP so Android can ship within this semester!!

## Overview
Currently, `/tracking` is an endpoint for `ithaca-transit-backend`, and right now it isn't returning data for the buses, and so the iOS and Android clients can't draw the buses on the map. This is the second step in my refactoring plan for addressing this issue:

1. Microservice parses protobuf for vehicle information from the TCAT third-party endpoint on vehicle positions
2. `/tracking` on ithaca-transit-backend needs to be modified so that it uses the newly merged ithaca-transit-microservice's `/vehicles` which takes in a `tripID` and `routeID` and returns important info like `longitude` and `latitude` which will help draw the buses. I originally wanted to make a new endpoint `/vehicle` but I decided that the old URL we were hitting for the data was completely irrelevant and no longer updated by TCAT's third-party vendor, so I ended up just scratching all of that and rewrote `/tracking`
3. We need to update the swagger docs that shows the updated `/tracking`, which is now able to take in an array of info and return the info as an array: `[{tripID, routeID}, ..., {tripID, routeID}]` returned as `[{bearing, longitude, latitude, speed, etc}, {bearing, etc}, ... {}]`

This PR is step 2, I will be making one more PR soon on `ithaca-transit-backend` that addresses step 3.

## Changes Made
I rewrote `/tracking` by adding new `fetchVehicles` and `getVehicleInformation` functions, which essentially mirrors what `fetchRTF` and `getDelayInformation` are doing. It made sense to do this because it was pretty clean and easy to understand already.

In general, the OG code for `/tracking` was just absolutely h o r r e n d o u s as I could not understand what the heck was going on! Apologies that this hard work was completely scrapped!!

I also had to update the `docker-compose.yml` so that the most recent images with the most recent GTFS data could be used while I was testing locally. Most notably, the image `transit-python:alanna` is my current test Docker image that has the step 1 change in master. 

## Test Coverage
Works locally. Will be letting this sit on the dev server for a bit though!

## Next Steps
Updating swagger docs.

## Related PRs or Issues
Step 1: https://github.com/cuappdev/ithaca-transit-tcat-microservice/pull/49

## Screenshots 
<img width="505" alt="Screen Shot 2020-04-05 at 12 35 39 PM" src="https://user-images.githubusercontent.com/13739525/78508377-41446a80-773b-11ea-8947-0ee156b5d452.png">
