### PR TITLE
Update `routeID` to be `routeNumber` in `\tracking` for consistency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "8987:8987"
 
   live-tracking:
-    image: cornellappdev/transit-python:alanna
+    image: cornellappdev/transit-python:v1.2.2
     env_file: python.envrc
     ports:
       - "5000:5000"

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -246,20 +246,20 @@
           {
             "in": "body",
             "name": "body",
-            "description": "The bus information to get the live location and other relevant vehicle data from. The request body has only one field, data, which is an array of objects with the following fields: \n* routeID: The number of the bus route.\n* tripID: The unique trip identifier for the specific `routeID`.\n Ex. {\"data\": [{\"routeID\": string, \"tripID\": string}]",
+            "description": "The bus information to get the live location and other relevant vehicle data from. The request body has only one field, data, which is an array of objects with the following fields: \n* routeNumber: The number of the bus route.\n* tripID: The unique trip identifier for the specific `routeNumber`.\n Ex. {\"data\": [{\"routeNumber\": integer, \"tripID\": string}]",
             "required": true,
             "schema": {
               "type": "array",
               "items": {
                 "type": "object",
                 "required": [
-                  "routeID",
+                  "routeNumber",
                   "tripID"
                 ],
                 "properties": {
-                  "routeID": {
+                  "routeNumber": {
                     "type": "integer",
-                    "example": "10"
+                    "example": 10
                   },
                   "tripID": {
                     "type": "string",
@@ -405,8 +405,8 @@
           "type": "double",
           "example": -76.55484845435
         },
-        "routeID": {
-          "type": "string",
+        "routeNumber": {
+          "type": "integer",
           "example": 77
         },
         "speed": {

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -107,7 +107,7 @@ function getVehicleInformation(
     return null;
   }
 
-  const vehicleData = Object.values(vehicles).find(v => v.routeID == routeNumber && v.tripID === tripID);
+  const vehicleData = Object.values(vehicles).find(v => parseInt(v.routeID) === routeNumber && v.tripID === tripID);
   if (!vehicleData) {
     LogUtils.log({
       category: 'getVehicleInformation no data',

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -107,7 +107,9 @@ function getVehicleInformation(
     return null;
   }
 
-  const vehicleData = Object.values(vehicles).find(v => parseInt(v.routeID) === routeNumber && v.tripID === tripID);
+  const vehicleData = Object.values(vehicles).find(
+    v => parseInt(v.routeID) === routeNumber && v.tripID === tripID,
+  );
   if (!vehicleData) {
     LogUtils.log({
       category: 'getVehicleInformation no data',

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -40,8 +40,8 @@ async function getTrackingResponse(requestData: Object): Object {
   console.log('vehicles', vehicles);
 
   const trackingInformation = requestData.map((data) => {
-    const { routeID, tripID } = data;
-    const vehicleData = getVehicleInformation(routeID, tripID, vehicles);
+    const { routeNumber, tripID } = data;
+    const vehicleData = getVehicleInformation(routeNumber, tripID, vehicles);
     if (!vehicleData) {
       LogUtils.log({ message: 'getVehicleResponse: noData', vehicleData });
       return null;
@@ -90,25 +90,43 @@ function getDelayInformation(
 }
 
 function getVehicleInformation(
-  routeID: ?String,
+  routeNumber: ?Number,
   tripID: ?String,
   vehicles: ?Object,
 ): ?Object {
   // vehicles param ensures the vehicle tracking information doesn't update in
   // the middle of execution
-  if (!routeID
+  if (!routeNumber
     || !tripID
     || !vehicles
     || vehicles === {}) {
     LogUtils.log({
       category: 'getVehicleInformation NULL',
-      routeID,
+      routeNumber,
       tripID,
     });
     return null;
   }
 
-  return Object.values(vehicles).find(v => v.routeID === routeID && v.tripID === tripID);
+  const vehicleData = Object.values(vehicles).find(v => v.routeID == routeNumber && v.tripID === tripID);
+  if (!vehicleData) {
+    LogUtils.log({
+      category: 'getVehicleInformation no data',
+      routeNumber,
+      tripID,
+    });
+    return null;
+  }
+  return {
+    bearing: vehicleData.bearing,
+    congestionLevel: vehicleData.congestionLevel,
+    latitude: vehicleData.latitude,
+    longitude: vehicleData.longitude,
+    routeNumber,
+    speed: vehicleData.speed,
+    timestamp: vehicleData.timestamp,
+    tripID,
+  };
 }
 
 export default {

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -37,7 +37,6 @@ async function fetchVehicles(): Object {
 async function getTrackingResponse(requestData: Object): Object {
   LogUtils.log({ message: 'getTrackingResponse: entering function' });
   const vehicles = await fetchVehicles();
-  console.log('vehicles', vehicles);
 
   const trackingInformation = requestData.map((data) => {
     const { routeNumber, tripID } = data;


### PR DESCRIPTION
## Overview
Right now `/tracking` requires `routeID` and returns `routeID` but the Android team helped me realize that our backend views the `routeID` in the GTFS data (string in the GTFS) but returns it as a `routeNumber` (type Number). So I needed to make that change so that backend is consistent. I didn't choose to modify this in the microservice, because the whole point of the python code is to abstract that away from having to deal with what the clients know about our backend. 

## Changes Made
Changed references of `routeID` to `routeNumber` and changed data type of string to number.
Updated docker compose to run locally.
Updated swagger docs to reflect new required field in request body and new field in response body.



## Test Coverage
Works locally, will be pushing onto servers soon.


## Related PRs or Issues 
#293 updated

## Screenshots
<img width="631" alt="Screen Shot 2020-04-11 at 2 08 10 PM" src="https://user-images.githubusercontent.com/13739525/79054937-fbd1e280-7bfd-11ea-8c6a-3a6088a74c9b.png">
