### PR TITLE
Update Graphhopper Dockerfile to be buildable

### DIFF
--- a/docker-compose/ghopper/Dockerfile
+++ b/docker-compose/ghopper/Dockerfile
@@ -16,8 +16,6 @@ RUN ./graphhopper.sh -a build
 
 EXPOSE 8988
 
-RUN ls web/target
-
 CMD java -Xmx4g -Xms4g \
   -Ddw.graphhopper.datareader.file=../map.osm \
   -Ddw.graphhopper.gtfs.file=../tcat-ny-us.zip \

--- a/docker-compose/ghopper/Dockerfile
+++ b/docker-compose/ghopper/Dockerfile
@@ -8,21 +8,22 @@ WORKDIR /usr/src/app
 RUN apt-get update
 RUN apt-get -y install maven wget
 
-RUN git clone --single-branch -b 0.11 https://github.com/graphhopper/graphhopper.git
+RUN git clone https://github.com/graphhopper/graphhopper.git
 RUN wget https://s3.amazonaws.com/tcat-gtfs/tcat-ny-us.zip
 
 WORKDIR /usr/src/app/graphhopper
-RUN ./graphhopper.sh --action build
+RUN ./graphhopper.sh -a build
 
 EXPOSE 8988
 
+RUN ls web/target
+
 CMD java -Xmx4g -Xms4g \
-  -Dgraphhopper.datareader.file=../map.osm \
-  -Dgraphhopper.gtfs.file=../tcat-ny-us.zip \
-  -Dgraphhopper.jetty.resourcebase=./graphhopper/web/src/main/webapp \
-  -Dgraphhopper.graph.flag_encoders=pt \
-  -Dgraphhopper.prepare.ch.weightings=no \
-  -Dgraphhopper.graph.location=./graph-cache \
-  -Ddw.server.applicationConnectors[0].bindHost=0.0.0.0 \
-  -Ddw.server.applicationConnectors[0].port=8988 \
-  -jar web/target/graphhopper-web-0.11-SNAPSHOT.jar server config.yml
+  -Ddw.graphhopper.datareader.file=../map.osm \
+  -Ddw.graphhopper.gtfs.file=../tcat-ny-us.zip \
+  -Ddw.graphhopper.jetty.resourcebase=./graphhopper/web/src/main/webapp \
+  -Ddw.graphhopper.prepare.ch.weightings=no \
+  -Ddw.graphhopper.graph.location=./graph-cache \
+  -Ddw.server.application_connectors[0].bind_host=0.0.0.0 \
+  -Ddw.server.application_connectors[0].port=8988 \
+  -jar web/target/graphhopper-web-*-SNAPSHOT.jar server config.yml


### PR DESCRIPTION
## Overview
Thanks to the legendary @meganle the Graphhopper Dockerfile has now been updated! TCAT updated the GTFS data and I had to rebuild a new Graphhopper Docker image but there was an issue with the `0.11-SNAPSHOT` jar file at `docker build`. With trial and error and dank googling skills, Megan was able to finesse this hella random fix (apparently master was broken at some point and the Graphhopper ppl fixed it). All credit cedes to her!!

## Changes Made
Deleted the branch flags when cloning the Graphhopper repo and updated the Docker CMDs, particularly the jar file at runtime (when the Docker image is executed as a container).

## Test Coverage
Currently sitting on our ghopper server. Our live tracking had been crashing due to old trip ids, so this should be the fix. We have no choice otherwise--any other issue is most definitely the data being incorrect.


