### PR TITLE
Strip date of milliseconds to fix 4:07 error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - /usr/src/app/node_modules
 
   ghopper:
-    image: cornellappdev/transit-ghopper:v1.2.1
+    image: cornellappdev/transit-ghopper:v1.2.6
     ports:
       - "8988:8988"
 
@@ -28,7 +28,7 @@ services:
       - "8987:8987"
 
   live-tracking:
-    image: cornellappdev/transit-python:v1.2.2
+    image: cornellappdev/transit-python:v1.2.6
     env_file: python.envrc
     ports:
       - "5000:5000"

--- a/docker-compose/ghopper/Dockerfile
+++ b/docker-compose/ghopper/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update
 RUN apt-get -y install maven wget
 
 RUN git clone --single-branch -b 0.13 https://github.com/graphhopper/graphhopper.git
-RUN wget https://s3.amazonaws.com/tcat-gtfs/tcat-ny-us.zip
+COPY tcat-ny-us.zip /usr/src/app/tcat-ny-us.zip
 
 WORKDIR /usr/src/app/graphhopper
 RUN ./graphhopper.sh build

--- a/src/utils/ParseRouteUtils.js
+++ b/src/utils/ParseRouteUtils.js
@@ -437,16 +437,14 @@ function parseWalkingRoute(
  * @param date
  * @returns formatted date string
  */
-function formatDate(
-  date: string,
-): string {
+function formatDate(date: string): string {
   if (date) {
     const dateBeforeMs = date.split('.')[0];
     if (date === dateBeforeMs) {
       // date already does not have milliseconds
       return date;
     }
-    return `${date.split('.')[0]}Z`;
+    return `${dateBeforeMs}Z`;
   }
   return date;
 }

--- a/src/utils/ParseRouteUtils.js
+++ b/src/utils/ParseRouteUtils.js
@@ -430,6 +430,28 @@ function parseWalkingRoute(
 }
 
 /**
+ * Ensure that the route times are in this format: "2020-08-27T23:11:58Z".
+ * Sometimes, we will get dates in the format of "2020-08-27T23:11:58.741+0000"
+ * and if this is the case, strip the milliseconds off. Otherwise, return the
+ * date we were given.
+ * @param date
+ * @returns formatted date string
+ */
+function formatDate(
+  date: string,
+): string {
+  if (date) {
+    const dateBeforeMs = date.split('.')[0];
+    if (date === dateBeforeMs) {
+      // date already does not have milliseconds
+      return date;
+    }
+    return `${date.split('.')[0]}Z`;
+  }
+  return date;
+}
+
+/**
  * Transform route object from graphhopper into one readable by the client, an array of
  * five routes. Includes delay calculations, asynchronous.
  *
@@ -469,7 +491,8 @@ function parseRoutes(
 
       // string 2018-02-21T17:27:00Z
       let { departureTime } = legs[0];
-      let arriveTime = legs[numberOfLegs - 1].arrivalTime;
+      departureTime = formatDate(departureTime);
+      let arriveTime = formatDate(legs[numberOfLegs - 1].arrivalTime);
 
       // Readjust the walking start and end times by accounting for the buffer
       // times that were initially passed into Graphhopper to get routes
@@ -497,8 +520,8 @@ function parseRoutes(
 
       const directions = await Promise.all(legs.map(async (currLeg, j, legsArray) => {
         let { type } = currLeg;
-        let startTime = currLeg.departureTime;
-        let endTime = currLeg.arrivalTime;
+        let startTime = formatDate(currLeg.departureTime);
+        let endTime = formatDate(currLeg.arrivalTime);
 
         if (busRoute.transfers === -1) {
           startTime = departureTime;


### PR DESCRIPTION
## Overview
The date time we get from TCAT has changed format sometime over the summer. They now include milliseconds unfortunately. We need to revert this format back to what it was so that clients don't break.

Date format we had before that we should maintain: `yyyy-MM-dd'T'HH:mm:ssZZZZ`
Date format that TCAT changed to over the summer: `yyyy-MM-dd'T'HH:mm:ss.SSSZ`

## Changes Made
* Stripped milliseconds off dates from TCAT if they exist
* Updated `docker-compose.yml` so we can run things locally with this change
* Updated the `ghopper` `Dockerfile` because Tom sent me data manually (can't fetch from the URL) so to keep versions matching with docker images, we should have master keep this change--once we can start fetching again (Aug 30), I'll update master

## Test Coverage
* Currently deployed on prod and dev from my branch and all is well
   * A temp fix similar to this one is currently deployed on prod from my branch as `transit-node:v1.1.4`
   * This PR fix is currently deployed on dev as `transit-dev:date`
* We need to add a test on integration that ensures that our date formats are correct! Made an issue on the integration repo [here](https://github.com/cuappdev/integration/issues/27).

## Screenshots
Error on the left, fix on the right

 | <img src="https://user-images.githubusercontent.com/13739525/91604178-0bd72e00-e923-11ea-95d1-16ece7843e47.png" width="300"/> | <img src="https://user-images.githubusercontent.com/13739525/91604533-ac2d5280-e923-11ea-858f-cd8aadd2e672.png" width="300"/> |
|-----------|------|
