### PR TITLE
Update PR template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing to Ithaca Transit Backend
+👍🎉 First off, congrats on getting put on this pod 😂🎉👍
+
+The following is a set of guidelines for contributing to our backend. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+# Making PRs
+We want our PRs to be concise but informative. Some pointers as per our PR template:
+* Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model"
+* "Overview" should just summarize changes
+* "Changes" should iclude details of what your changes actually are and how it is intended to work.
+* "Test Coverage" should describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. In the context of this repo, add a plan for how you intend to test on [integration](https://github.com/cuappdev/integration), with your newly created issue linked.
+* "Next Steps" (if applicable) should describe how you plan on addressing future PRs if this is a part of a multi-PR change.
+* "Related PRs or Issues" (if applicable) should list related PRs against other branches or repositories. This is often the case for our backend, because we work with two other repositories: [ithaca-transit-tcat-microservice](https://github.com/cuappdev/ithaca-transit-tcat-microservice) and [integration](https://github.com/cuappdev/integration).
+
+# Versioning
+We want to keep our [transit-node](https://hub.docker.com/repository/docker/cornellappdev/transit-node), [transit-ghopper](https://hub.docker.com/repository/docker/cornellappdev/transit-ghopper), and [transit-python](https://hub.docker.com/repository/docker/cornellappdev/transit-python) images synced with the right releases on our repositories. We update [releases on this repository](https://github.com/cuappdev/ithaca-transit-backend/releases) and [releases on ithaca-transit-microservice](https://github.com/cuappdev/ithaca-transit-tcat-microservice/releases). Everytime you decide to build a new Docker image and deploy onto our servers (transit-prod, transit-dev, and transit-bus), you must create a release on our master branch so that we know which commit corresponds to which image deployed. This way, if an error occurs, we can quickly diagnose the issue and roll back the last change that we know is safe. 
+We keep a Dropbox Paper doc, [Transit Backend Versions](https://paper.dropbox.com/doc/Transit-Backend-Versions-RZD26Pqv1VGqOy04KEpQs) (which only AppDev member have access to), that keeps track of which versions are in sync. For example, two Docker images that must be kept in sync are transit-ghopper and transit-python because their GTFS static data *must* be the same, so we increase our versioning (ex. v1.1.1 -> v1.1.2) if we update the data--even if we don't change our code. This may result in jumps in versioning, so it may be the case that Github has releases v1.1.3 and v1.1.6, missing three versions in between as a result of data updates. This repository, unlike the microservice, does not have to worry about this issue: transit-node can have different versions as transit-ghopper and transit-python. 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,12 +5,18 @@ The following is a set of guidelines for contributing to our backend. These are 
 
 # Making PRs
 We want our PRs to be concise but informative. Some pointers as per our PR template:
-* Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model"
-* "Overview" should just summarize changes
-* "Changes" should iclude details of what your changes actually are and how it is intended to work.
-* "Test Coverage" should describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. In the context of this repo, add a plan for how you intend to test on [integration](https://github.com/cuappdev/integration), with your newly created issue linked.
-* "Next Steps" (if applicable) should describe how you plan on addressing future PRs if this is a part of a multi-PR change.
-* "Related PRs or Issues" (if applicable) should list related PRs against other branches or repositories. This is often the case for our backend, because we work with two other repositories: [ithaca-transit-tcat-microservice](https://github.com/cuappdev/ithaca-transit-tcat-microservice) and [integration](https://github.com/cuappdev/integration).
+## Title
+Summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model."
+## Overview
+Summarize generally what the purpose of this PR is.
+## Changes
+Include details of what your changes actually are and how it is intended to work.
+## Test Coverage
+Describe how you tested this feature: manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. In the context of this repo, add a plan for how you intend to test on [integration](https://github.com/cuappdev/integration), with your newly created issue linked.
+## Next Steps
+If this applies, describe how you plan on addressing future PRs if this is a part of a multi-PR change.
+## Related PRs or Issues
+If this applies, list related PRs against other branches or repositories. This is often the case for our backend, because we work with two other repositories: [ithaca-transit-tcat-microservice](https://github.com/cuappdev/ithaca-transit-tcat-microservice) and [integration](https://github.com/cuappdev/integration).
 
 # Versioning
 We want to keep our [transit-node](https://hub.docker.com/repository/docker/cornellappdev/transit-node), [transit-ghopper](https://hub.docker.com/repository/docker/cornellappdev/transit-ghopper), and [transit-python](https://hub.docker.com/repository/docker/cornellappdev/transit-python) images synced with the right releases on our repositories. We update [releases on this repository](https://github.com/cuappdev/ithaca-transit-backend/releases) and [releases on ithaca-transit-microservice](https://github.com/cuappdev/ithaca-transit-tcat-microservice/releases). Everytime you decide to build a new Docker image and deploy onto our servers (transit-prod, transit-dev, and transit-bus), you must create a release on our master branch so that we know which commit corresponds to which image deployed. This way, if an error occurs, we can quickly diagnose the issue and roll back the last change that we know is safe. 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,21 +3,28 @@
 
 The following is a set of guidelines for contributing to our backend. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
+# Versioning
+This is _extremely_ important as handling our backend can get quite messy.
+
+## Keep Docker images in sync with repository tags
+We want to keep our [transit-node](https://hub.docker.com/repository/docker/cornellappdev/transit-node), [transit-ghopper](https://hub.docker.com/repository/docker/cornellappdev/transit-ghopper), and [transit-python](https://hub.docker.com/repository/docker/cornellappdev/transit-python) images synced with the right releases on our repositories. We update [releases on this repository](https://github.com/cuappdev/ithaca-transit-backend/releases) and [releases on ithaca-transit-microservice](https://github.com/cuappdev/ithaca-transit-tcat-microservice/releases). 
+Everytime you decide to build a new Docker image and deploy onto our servers (transit-prod, transit-dev, and transit-bus), you must create a release on our master branch so that we know which commit corresponds to which image deployed. This way, if an error occurs, we can quickly diagnose the issue and roll back the last change that we know is safe. 
+## Document versions
+We keep a Dropbox Paper doc, [Transit Backend Versions](https://paper.dropbox.com/doc/Transit-Backend-Versions-RZD26Pqv1VGqOy04KEpQs) (which only AppDev member have access to), that keeps track of which versions are in sync between all three images. For example, two Docker images that must be kept in sync are transit-ghopper and transit-python because their GTFS static data *must* be the same, so we increase our versioning (ex. v1.1.1 -> v1.1.2) if we update the data--even if we don't change our code. This may result in jumps in versioning, so it may be the case that Github has releases v1.1.3 and v1.1.6, missing three versions in between as a result of data updates. This repository, unlike the microservice, does not have to worry about this issue: transit-node can have different versions as transit-ghopper and transit-python. 
+
 # Making PRs
 We want our PRs to be concise but informative. Some pointers as per our PR template:
-## Title
+### Title
 Summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model."
-## Overview
+### Overview
 Summarize generally what the purpose of this PR is.
-## Changes
+### Changes
 Include details of what your changes actually are and how it is intended to work.
-## Test Coverage
+### Test Coverage
 Describe how you tested this feature: manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. In the context of this repo, add a plan for how you intend to test on [integration](https://github.com/cuappdev/integration), with your newly created issue linked.
-## Next Steps
+### Next Steps
 If this applies, describe how you plan on addressing future PRs if this is a part of a multi-PR change.
-## Related PRs or Issues
+### Related PRs or Issues
 If this applies, list related PRs against other branches or repositories. This is often the case for our backend, because we work with two other repositories: [ithaca-transit-tcat-microservice](https://github.com/cuappdev/ithaca-transit-tcat-microservice) and [integration](https://github.com/cuappdev/integration).
 
-# Versioning
-We want to keep our [transit-node](https://hub.docker.com/repository/docker/cornellappdev/transit-node), [transit-ghopper](https://hub.docker.com/repository/docker/cornellappdev/transit-ghopper), and [transit-python](https://hub.docker.com/repository/docker/cornellappdev/transit-python) images synced with the right releases on our repositories. We update [releases on this repository](https://github.com/cuappdev/ithaca-transit-backend/releases) and [releases on ithaca-transit-microservice](https://github.com/cuappdev/ithaca-transit-tcat-microservice/releases). Everytime you decide to build a new Docker image and deploy onto our servers (transit-prod, transit-dev, and transit-bus), you must create a release on our master branch so that we know which commit corresponds to which image deployed. This way, if an error occurs, we can quickly diagnose the issue and roll back the last change that we know is safe. 
-We keep a Dropbox Paper doc, [Transit Backend Versions](https://paper.dropbox.com/doc/Transit-Backend-Versions-RZD26Pqv1VGqOy04KEpQs) (which only AppDev member have access to), that keeps track of which versions are in sync. For example, two Docker images that must be kept in sync are transit-ghopper and transit-python because their GTFS static data *must* be the same, so we increase our versioning (ex. v1.1.1 -> v1.1.2) if we update the data--even if we don't change our code. This may result in jumps in versioning, so it may be the case that Github has releases v1.1.3 and v1.1.6, missing three versions in between as a result of data updates. This repository, unlike the microservice, does not have to worry about this issue: transit-node can have different versions as transit-ghopper and transit-python. 
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,48 +1,17 @@
-<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->
-
-<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->
-
-
 ## Overview
-
-<!-- Summarize your changes here. -->
-
 
 
 ## Changes Made
 
-<!-- Include details of what your changes actually are and how it is intended to work. -->
-
-
 
 ## Test Coverage
 
-<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
+
+## Next Steps
 
 
-
-## Next Steps (delete if not applicable)
-
-<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->
+## Related PRs or Issues
 
 
-
-## Related PRs or Issues (delete if not applicable)
-
-<!-- List related PRs against other branches/repositories. -->
-
-
-
-## Screenshots (delete if not applicable)
-
-<!-- This could include of screenshots of the new feature / proof that the changes work. -->
-
-<details>
-
-  <summary>Screen Shot Name</summary>
-
-
-  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
-  
-
-</details>
+## Screenshots
+<img src="image url here" width="300"/>


### PR DESCRIPTION
## Overview
This is super meta but I getting really annoyed always having to delete the intro on how to make a good PR title. I think everyone here already knows how to do this...

Basically everytime I delete it, Github detects the markdown as the start of an issue:

<img width="429" alt="Screen Shot 2020-08-28 at 12 02 20 PM" src="https://user-images.githubusercontent.com/13739525/91606101-54dcb180-e926-11ea-8577-89574b4ddffe.png">



## Changes Made
* Remove redundant descriptions (like who doesn't understand this stuff after reading the titles??)
* Add an HTML tag template for adding images so that we can resize and that is *actually* useful instead of having to click on a dropdown and seeing some image swallow up your whole screen