### PR TITLE
Ensure /tracking is backwards compatible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "8987:8987"
 
   live-tracking:
-    image: cornellappdev/transit-python:v1.2.8
+    image: cornellappdev/transit-python:v1.2.9
     env_file: python.envrc
     ports:
       - "5000:5000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - /usr/src/app/node_modules
 
   ghopper:
-    image: cornellappdev/transit-ghopper:v1.2.6
+    image: cornellappdev/transit-ghopper:v1.2.8
     ports:
       - "8988:8988"
 
@@ -28,7 +28,7 @@ services:
       - "8987:8987"
 
   live-tracking:
-    image: cornellappdev/transit-python:v1.2.6
+    image: cornellappdev/transit-python:v1.2.8
     env_file: python.envrc
     ports:
       - "5000:5000"

--- a/docker-compose/ghopper/Dockerfile
+++ b/docker-compose/ghopper/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update
 RUN apt-get -y install maven wget
 
 RUN git clone --single-branch -b 0.13 https://github.com/graphhopper/graphhopper.git
-COPY tcat-ny-us.zip /usr/src/app/tcat-ny-us.zip
+RUN wget https://s3.amazonaws.com/tcat-gtfs/tcat-ny-us.zip
 
 WORKDIR /usr/src/app/graphhopper
 RUN ./graphhopper.sh build

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -137,8 +137,6 @@ function getVehicleInformation(
   tripID: ?String,
   vehicles: ?Object,
 ): ?Object {
-  console.log(vehicles);
-
   // vehicles param ensures the vehicle tracking information doesn't update in
   // the middle of execution
   if (!routeID
@@ -162,7 +160,7 @@ function getVehicleInformation(
       tripID,
     });
     return {
-      dataType: 'case',
+      case: 'noData',
       delay: 0,
       destination: '',
       deviation: 0,
@@ -185,7 +183,7 @@ function getVehicleInformation(
     };
   }
   return {
-    dataType: 'case',
+    case: 'validData',
     delay: 0,
     destination: '',
     deviation: 0,

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -137,6 +137,8 @@ function getVehicleInformation(
   tripID: ?String,
   vehicles: ?Object,
 ): ?Object {
+  console.log(vehicles);
+
   // vehicles param ensures the vehicle tracking information doesn't update in
   // the middle of execution
   if (!routeID
@@ -160,7 +162,7 @@ function getVehicleInformation(
       tripID,
     });
     return {
-      dataType: 'noData',
+      dataType: 'case',
       delay: 0,
       destination: '',
       deviation: 0,
@@ -177,21 +179,20 @@ function getVehicleInformation(
       routeID: Number(routeID), // although input is string, old clients expect a number
       runID: 0,
       speed: 0,
-      tripID,
+      tripID: 0,
       vehicleID: 0,
-      bearing: 0,
       congestionLevel: 0,
     };
   }
   return {
-    dataType: 'validData',
+    dataType: 'case',
     delay: 0,
     destination: '',
     deviation: 0,
     direction: '',
     displayStatus: '',
     gpsStatus: 0,
-    heading: 0,
+    heading: vehicleData.bearing,
     lastStop: '',
     lastUpdated: vehicleData.timestamp,
     latitude: vehicleData.latitude,
@@ -200,10 +201,9 @@ function getVehicleInformation(
     opStatus: '',
     routeID: Number(routeID), // although input is string, old clients expect a number
     runID: 0,
-    speed: vehicleData.speed,
-    tripID,
-    vehicleID: 0,
-    bearing: vehicleData.bearing,
+    speed: parseInt(vehicleData.speed),
+    tripID: 0,
+    vehicleID: Number(vehicleData.vehicleID),
     congestionLevel: vehicleData.congestionLevel,
   };
 }

--- a/src/utils/RealtimeFeedUtils.js
+++ b/src/utils/RealtimeFeedUtils.js
@@ -149,7 +149,7 @@ function getVehicleInformation(
 
   console.log('vehicles', vehicles);
   const vehicleData = Object.values(vehicles).find(
-    v => (v.routeID == routeID) && (v.tripID === tripID),
+    v => (Number(v.routeID) === routeID) && (v.tripID === tripID),
     // v.routeID === routeID && v.tripID === tripID,
   );
   console.log('vehicledata', vehicleData);
@@ -159,17 +159,52 @@ function getVehicleInformation(
       routeID,
       tripID,
     });
-    return null;
+    return {
+      dataType: 'noData',
+      delay: 0,
+      destination: '',
+      deviation: 0,
+      direction: '',
+      displayStatus: '',
+      gpsStatus: 0,
+      heading: 0,
+      lastStop: '',
+      lastUpdated: 0,
+      latitude: 0,
+      longitude: 0,
+      name: '',
+      opStatus: '',
+      routeID,
+      runID: 0,
+      speed: 0,
+      tripID,
+      vehicleID: 0,
+      bearing: 0,
+      congestionLevel: 0,
+    };
   }
   return {
-    bearing: vehicleData.bearing,
-    congestionLevel: vehicleData.congestionLevel,
+    dataType: 'validData',
+    delay: 0,
+    destination: '',
+    deviation: 0,
+    direction: '',
+    displayStatus: '',
+    gpsStatus: 0,
+    heading: 0,
+    lastStop: '',
+    lastUpdated: vehicleData.timestamp,
     latitude: vehicleData.latitude,
     longitude: vehicleData.longitude,
+    name: '',
+    opStatus: '',
     routeID,
+    runID: 0,
     speed: vehicleData.speed,
-    timestamp: vehicleData.timestamp,
     tripID,
+    vehicleID: 0,
+    bearing: vehicleData.bearing,
+    congestionLevel: vehicleData.congestionLevel,
   };
 }
 


### PR DESCRIPTION
## Overview
### ⚠️ Please check the below example requests before you ask me questions plz ⚠️

### A *!! VERY IMPORTANT !!* note to Android & iOS Refactorers:
Last semester, Android requested that I change the POST request field `routeID:string` to be `routeNumber:integer` because that was consistent with `v2/route`. However, this won't work with old iOS clients, who send in `routeID:string` and expect `routeID:integer` as a response. Don't ask me why this isn't consistent, but it looks like Android will just have to deal with this. So, whatever we return `routeNumber:integer` in `v2/route`, just change the name to `routeID` and cast it to a string before putting into `v2/tracking`. Make sure you expect the response to be `routeID:integer` as well.



Thanks to @Omarrasheed, I've updated the response to include everything that the iOS clients need:

![Screen Shot 2020-09-10 at 4 32 46 PM](https://user-images.githubusercontent.com/13739525/92810297-481e7b80-f372-11ea-9873-1eea67cf90ee.png)

## Changes Made
Update /tracking so that old iOS clients still work
Update docker images so we can run locally

## Test Coverage
Tested locally works, going to be deploying

## Next Steps
Update microservice to include vehicle id and other fields

## Related PRs or Issues
#292 
#295 

## Old Request Example - let's try to deprecate this
### Request Body
<img width="600" alt="Screen Shot 2020-09-10 at 2 23 07 PM" src="https://user-images.githubusercontent.com/13739525/92809092-27095b00-f371-11ea-8281-7bc31fb561d9.png">
For you to copy and paste:
{
  "data" : [
    {
      "stopID" : "523",
      "routeID" : "82",
      "tripIdentifiers" : [
        "t6A4-b1D-slC", "t60B-b7-slC"
      ]
    },
    {
      "stopID" : "1701",
      "routeID" : "30",
      "tripIdentifiers" : [
        "t60B-b7-slC"
      ]
    }
  ]
}

### Response Body
[backwards_compat.txt](https://github.com/cuappdev/ithaca-transit-backend/files/5204729/backwards_compat.txt)




## New Request Example
### Request Body
<img width="860" alt="Screen Shot 2020-09-10 at 2 27 12 PM" src="https://user-images.githubusercontent.com/13739525/92809712-b9116380-f371-11ea-82c0-48a3b161be05.png">
For you to copy and paste:
{
    "data": [
        {
            "tripID": "t665-bF-slC",
            "routeID": "41"
        },
        {
            "tripID": "t64D-b30-slC",
            "routeID": "37"
        }
]
}

### Response Body
[same_response_diff_values.txt](https://github.com/cuappdev/ithaca-transit-backend/files/5204755/same_response_diff_values.txt)
