### PR TITLE
Update docs to have v2 at /tracking and /delays

### DIFF
--- a/src/swagger.json
+++ b/src/swagger.json
@@ -397,6 +397,10 @@
           "type": "integer",
           "example": 0
         },
+        "lastUpdated": {
+          "type": "integer",
+          "example": 1599773185
+        },
         "latitude": {
           "type": "double",
           "example": 42.459849543945
@@ -405,17 +409,17 @@
           "type": "double",
           "example": -76.55484845435
         },
-        "routeNumber": {
+        "routeID": {
           "type": "integer",
           "example": 77
         },
         "speed": {
           "type": "double",
-          "example": 0.0
+          "example": 9.834879875183105
         },
-        "timestamp": {
+        "vehicleID": {
           "type": "integer",
-          "example": 1586033827
+          "example": 0
         },
         "tripID": {
           "type": "string",

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -246,18 +246,18 @@
           {
             "in": "body",
             "name": "body",
-            "description": "The bus information to get the live location and other relevant vehicle data from. The request body has only one field, data, which is an array of objects with the following fields: \n* routeNumber: The number of the bus route.\n* tripID: The unique trip identifier for the specific `routeNumber`.\n Ex. {\"data\": [{\"routeNumber\": integer, \"tripID\": string}]",
+            "description": "The bus information to get the live location and other relevant vehicle data from. The request body has only one field, data, which is an array of objects with the following fields: \n* routeID: The number of the bus route. Note this corresponds to routeNumber from v2/route (v2/route has bad naming, so please stick with this in the meantime). \n* tripID: The unique trip identifier for the specific `routeID`.\n Ex. {\"data\": [{\"routeID\": integer, \"tripID\": string}]",
             "required": true,
             "schema": {
               "type": "array",
               "items": {
                 "type": "object",
                 "required": [
-                  "routeNumber",
+                  "routeID",
                   "tripID"
                 ],
                 "properties": {
-                  "routeNumber": {
+                  "routeID": {
                     "type": "integer",
                     "example": 10
                   },

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -45,7 +45,7 @@
         }
       }
     },
-    "/delays": {
+    "/v2/delays": {
       "post": {
         "summary": "Return a list of bus delays for buses at a specific stop",
         "description": "Takes in a list of objects with fields routeID and trip ID and returns a list of objects with fields routeID, tripID, and delay.",
@@ -236,7 +236,7 @@
         }
       }
     },
-    "/tracking": {
+    "/v2/tracking": {
       "post": {
         "summary": "Return a list information about live bus information (to help draw buses on the map).",
         "produces": [


### PR DESCRIPTION
## Overview
Pretty important change because we have newbies on iOS and Android now -- I'm surprised I didn't catch this earlier :'(

## Changes Made
Just add a trivial "v2" in front of two endpoints and update /tracking [since I last made it backwards compatible](https://github.com/cuappdev/ithaca-transit-backend/pull/305) and decided to not use `routeNumber` so that we could make a v3 route that was better (we call GTFS's `routeID` a `routeNumber` which is pretty jank...)

## Test Coverage
Just docs 

## Next Steps
Nothing, this is just docs

## Related PRs or Issues
#267 
