### PR TITLE
Begin v3/route by copying v2 into a new v3

### DIFF
--- a/src/API.js
+++ b/src/API.js
@@ -39,6 +39,10 @@ class API extends ApplicationAPI {
         ...sharedRouters,
         Routers.RouteV2Router,
       ],
+      v3: [
+        ...sharedRouters,
+        Routers.RouteV3Router,
+      ],
     };
   }
 }

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -12,6 +12,7 @@ import PlaceIDCoordinatesRouter from './v1/PlaceIDCoordinatesRouter';
 import RouteRouter from './v1/RouteRouter';
 import RouteSelectedRouter from './v1/RouteSelectedRouter';
 import RouteV2Router from './v2/RouteRouter';
+import RouteV3Router from './v3/RouteRouter';
 import SearchRouter from './v1/SearchRouter';
 import TrackingRouter from './v1/TrackingRouter';
 
@@ -30,6 +31,7 @@ export default {
   RouteRouter,
   RouteSelectedRouter,
   RouteV2Router,
+  RouteV3Router,
   SearchRouter,
   TrackingRouter,
 };

--- a/src/routers/v3/RouteRouter.js
+++ b/src/routers/v3/RouteRouter.js
@@ -1,0 +1,61 @@
+// @flow
+import type Request from 'express';
+import AnalyticsUtils from '../../utils/AnalyticsUtils';
+import ApplicationRouter from '../../appdev/ApplicationRouter';
+import LogUtils from '../../utils/LogUtils';
+import RouteUtils from '../../utils/RouteUtils';
+
+class RouteRouter extends ApplicationRouter<Object> {
+  constructor() {
+    super(['POST']);
+  }
+
+  getPath(): string {
+    return '/route/';
+  }
+
+  async content(req: Request): Promise<Object> {
+    const {
+      destinationName,
+      end,
+      arriveBy,
+      originName,
+      start,
+      time,
+      uid,
+    } = req.body;
+
+    const isArriveBy = (arriveBy === '1' || arriveBy === true || arriveBy === 'true' || arriveBy === 'True');
+
+    const isOriginBusStop = await RouteUtils.isBusStop(originName);
+    const originBusStopName = isOriginBusStop ? originName : null;
+    const sectionedRoutes = await RouteUtils.getSectionedRoutes(
+      originName,
+      destinationName,
+      end,
+      start,
+      time,
+      isArriveBy,
+      originBusStopName,
+    );
+    const routes = RouteUtils.flatten(Object.values(sectionedRoutes));
+    if (routes.length > 0) {
+      const request = {
+        isArriveBy,
+        destinationName,
+        end: routes[0].endCoords,
+        originName,
+        routeId: routes[0].routeId,
+        start: routes[0].startCoords,
+        time,
+        uid,
+      };
+      LogUtils.log({ category: 'routeRequest', request });
+    }
+    AnalyticsUtils.assignRouteIdsAndCache(routes);
+
+    return sectionedRoutes;
+  }
+}
+
+export default new RouteRouter().router;


### PR DESCRIPTION
## Overview
Some really redundant/jank things we want to get rid of from v2:
* routeSummary
* delays
* routeID -- no longer using for analytics!
* routeNumber -- since we delete routeID, we can change this to routeID

## Changes Made
* Copy v2 into a v3 route

## Test Coverage
Works locally, and although it's a minor change I'll be deploying to the server

## Next Steps
* Might want to consider refactoring delays to return the delays for a specific stop

## Related PRs or Issues
#307 
