### PR TITLE
Add Delay Route for Backwards Compatibility with iOS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - /usr/src/app/node_modules
 
   ghopper:
-    image: cornellappdev/transit-ghopper:v1.2.9
+    image: cornellappdev/transit-ghopper:11_29_20
     ports:
       - "8988:8988"
 
@@ -28,7 +28,7 @@ services:
       - "8987:8987"
 
   live-tracking:
-    image: cornellappdev/transit-python:v1.2.9
+    image: cornellappdev/transit-python:11_29_20
     env_file: python.envrc
     ports:
       - "5000:5000"

--- a/src/API.js
+++ b/src/API.js
@@ -37,6 +37,7 @@ class API extends ApplicationAPI {
       v2: [
         ...sharedRouters,
         Routers.RouteV2Router,
+        Routers.DelayV2Router,
         Routers.DelaysV2Router,
         Routers.TrackingRouter,
       ],

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -3,6 +3,7 @@ import AllStopsRouter from './v1/AllStopsRouter';
 import ApplePlacesRouter from './v1/ApplePlacesRouter';
 import AppleSearchRouter from './v1/AppleSearchRouter';
 import DelayRouter from './v1/DelayRouter';
+import DelayV2Router from './v2/DelayRouter';
 import DelaysV2Router from './v2/DelaysRouter';
 import DelaysV3Router from './v3/DelaysRouter';
 import DocsRouter from './DocsRouter';
@@ -24,6 +25,7 @@ export default {
   ApplePlacesRouter,
   AppleSearchRouter,
   DelayRouter,
+  DelayV2Router,
   DelaysV2Router,
   DelaysV3Router,
   DocsRouter,

--- a/src/routers/v2/DelayRouter.js
+++ b/src/routers/v2/DelayRouter.js
@@ -1,0 +1,22 @@
+// @flow
+import ApplicationRouter from '../../appdev/ApplicationRouter';
+import RealtimeFeedUtils from '../../utils/RealtimeFeedUtilsV3';
+
+class DelayRouter extends ApplicationRouter<Object> {
+  constructor() {
+    super(['GET']);
+  }
+
+  getPath(): string {
+    return '/delay/';
+  }
+
+  async content(req): Promise<any> {
+    const rtf = await RealtimeFeedUtils.fetchRTF();
+    const { stopID, tripID } = req.query;
+    const res = await RealtimeFeedUtils.getDelayInformation(stopID, tripID, rtf);
+    return res ? res.delay : null;
+  }
+}
+
+export default new DelayRouter().router;


### PR DESCRIPTION
## Overview
iOS uses a `v2/delay` route instead of `v2/delays` - for the sake of backwards compatibility with people who don't update, I added a delay route. 

## Changes Made
Added a new `DelayRouter` with similar functionality as `DelaysRouter`, but it only accepts a single trip, and accepts it via the query parameters instead of the request body (as in `v1`).  

## Test Coverage
Some manual testing, and ran integration locally. 