### PR TITLE
update ghopper wget url to modern aws path name

### DIFF
--- a/docker-compose/ghopper/Dockerfile
+++ b/docker-compose/ghopper/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update
 RUN apt-get -y install maven wget
 
 RUN git clone --single-branch -b 0.13 https://github.com/graphhopper/graphhopper.git
-RUN wget https://s3.amazonaws.com/tcat-gtfs/tcat-ny-us.zip
+RUN wget https://tcat-gtfs.s3.amazonaws.com/tcat-ny-us.zip
 
 WORKDIR /usr/src/app/graphhopper
 RUN ./graphhopper.sh build


### PR DESCRIPTION
## Overview
Ghopper GTFS wget URL was using old S3 path conventions that are planned to be deprecated. 

## Changes Made
Updated URL to modern style.

## Test Coverage
Built Dockerfile and it worked.