### PR TITLE
Nicole delay final time

### DIFF
--- a/src/utils/RouteUtilsV3.js
+++ b/src/utils/RouteUtilsV3.js
@@ -254,6 +254,30 @@ async function getSectionedRoutes(
     isArriveBy,
   );
 
+  LogUtils.log('new testing delay 1');
+  LogUtils.log(finalBusRoutes.length);
+
+  // finalBusRoutes.forEach((route) => {
+  //   let totalDelay = 0;
+  //   const { directions } = route;
+  //   LogUtils.log('testing delay');
+  //   for (let i = 0; i < directions.length; i++) {
+  //     const segment = directions[i];
+  //     const { delay } = segment;
+  //     LogUtils.log('heres the delay');
+  //     LogUtils.log(delay);
+  //     if (delay !== null) {
+  //       totalDelay += delay;
+  //     }
+  //   }
+  //   if (directions[-1].type === 'walk') {
+  //     directions[-1].delay = totalDelay;
+  //   }
+  // });
+
+  LogUtils.log('testing');
+  LogUtils.log(finalBusRoutes);
+
   finalBusRoutes.forEach((route) => {
     if (originBusStopName !== null
       && route.directions

--- a/src/utils/RouteUtilsV3.js
+++ b/src/utils/RouteUtilsV3.js
@@ -254,20 +254,21 @@ async function getSectionedRoutes(
     isArriveBy,
   );
 
-  // For each bus route, accumulate the total delay from all segments, and if the final segment is a 'walk' type,
-  // assign the total delay to the last 'walk' segment.
+  // Iterates over each route in finalBusRoutes, calculates total delay from bus segments,
+  // and applies this delay to the 'walk' segment if it follows a delayed bus segment.
   finalBusRoutes.forEach((route) => {
     let totalDelay = 0;
-    const directions = route.directions;
+    const { directions } = route;
+
     for (let i = 0; i < directions.length; i++) {
       const segment = directions[i];
-      const delay = segment.delay;
-      if (delay !== null) {
+      const { delay } = segment;
+
+      if (segment.type === 'walk' && totalDelay > 0) {
+        segment.delay = totalDelay;
+      } else if (delay !== null) {
         totalDelay += delay;
       }
-    }
-    if (directions[directions.length - 1].type === 'walk' && totalDelay > 0) {
-      directions[directions.length - 1].delay = totalDelay;
     }
   });
 

--- a/src/utils/RouteUtilsV3.js
+++ b/src/utils/RouteUtilsV3.js
@@ -257,23 +257,23 @@ async function getSectionedRoutes(
   LogUtils.log('new testing delay 1');
   LogUtils.log(finalBusRoutes.length);
 
-  // finalBusRoutes.forEach((route) => {
-  //   let totalDelay = 0;
-  //   const { directions } = route;
-  //   LogUtils.log('testing delay');
-  //   for (let i = 0; i < directions.length; i++) {
-  //     const segment = directions[i];
-  //     const { delay } = segment;
-  //     LogUtils.log('heres the delay');
-  //     LogUtils.log(delay);
-  //     if (delay !== null) {
-  //       totalDelay += delay;
-  //     }
-  //   }
-  //   if (directions[-1].type === 'walk') {
-  //     directions[-1].delay = totalDelay;
-  //   }
-  // });
+  finalBusRoutes.forEach((route) => {
+    let totalDelay = 0;
+    const { directions } = route;
+    LogUtils.log('testing delay');
+    for (let i = 0; i < directions.length; i++) {
+      const segment = directions[i];
+      const { delay } = segment;
+      LogUtils.log('heres the delay');
+      LogUtils.log(delay);
+      if (delay !== null) {
+        totalDelay += delay;
+      }
+    }
+    if (directions[-1].type === 'walk') {
+      directions[-1].delay = totalDelay;
+    }
+  });
 
   LogUtils.log('testing');
   LogUtils.log(finalBusRoutes);

--- a/src/utils/RouteUtilsV3.js
+++ b/src/utils/RouteUtilsV3.js
@@ -254,29 +254,22 @@ async function getSectionedRoutes(
     isArriveBy,
   );
 
-  LogUtils.log('new testing delay 1');
-  LogUtils.log(finalBusRoutes.length);
-
+  // For each bus route, accumulate the total delay from all segments, and if the final segment is a 'walk' type,
+  // assign the total delay to the last 'walk' segment.
   finalBusRoutes.forEach((route) => {
     let totalDelay = 0;
-    const { directions } = route;
-    LogUtils.log('testing delay');
+    const directions = route.directions;
     for (let i = 0; i < directions.length; i++) {
       const segment = directions[i];
-      const { delay } = segment;
-      LogUtils.log('heres the delay');
-      LogUtils.log(delay);
+      const delay = segment.delay;
       if (delay !== null) {
         totalDelay += delay;
       }
     }
-    if (directions[-1].type === 'walk') {
-      directions[-1].delay = totalDelay;
+    if (directions[directions.length - 1].type === 'walk' && totalDelay > 0) {
+      directions[directions.length - 1].delay = totalDelay;
     }
   });
-
-  LogUtils.log('testing');
-  LogUtils.log(finalBusRoutes);
 
   finalBusRoutes.forEach((route) => {
     if (originBusStopName !== null


### PR DESCRIPTION
## Overview
Fix bug where the final delay time is not accurate. 

## Changes Made
Added logic in `RouteUtilsV3.js` to iterate over each route in finalBusRoutes, calculates total delay from bus segments, and apply this delay to the 'walk' segment if it follows a delayed bus segment.

## Test Coverage
Tested routes with no delays, delays, final destination at bus stop, final destination not at bus stop. Finding routes with multiple different bus and walking segments that had delays were a bit difficult, so I just created my own route object with directions to test the code. 

## Next Steps


## Related PRs or Issues
[https://github.com/cuappdev/ithaca-transit-ios/issues/392](url)

## Screenshots
Original bug (delay not reflected in final time): 
<img width="856" alt="image" src="https://github.com/user-attachments/assets/308ba108-b99b-4c3c-aec5-d6bc104fbd35">

Request body:
{
  "end": "42.4403, -76.4962",
  "uid": "B1CD4726-0CA8-41DC-A2F4-01D5D8F3A3E0",
  "time": 1729604959,
  "destinationName": "Thompson and Bleeker",
  "start": "42.4852, -76.4909",
  "arriveBy": false,
  "originName": "Target"
}

One of the routes contains a bus delay: 
<img width="301" alt="image" src="https://github.com/user-attachments/assets/803f9d83-0551-44be-a99a-a017742d3d90">

Delay time reflected in final walking segment: 
<img width="251" alt="image" src="https://github.com/user-attachments/assets/c75a5d3c-462c-4b40-8631-685ce212e187">

