### PR TITLE
Reliability (Get and Report Bus Fullness) 

### DIFF
--- a/src/API.js
+++ b/src/API.js
@@ -25,6 +25,8 @@ class API extends ApplicationAPI {
       Routers.PlaceIDCoordinatesRouter,
       Routers.RouteSelectedRouter,
       Routers.SearchRouter,
+      Routers.ReportFullnessRouter,
+      Routers.GetFullnessRouter,
     ];
     return {
       docs: [Routers.DocsRouter],

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -18,6 +18,8 @@ import RouteV3Router from './v3/RouteRouter';
 import SearchRouter from './v1/SearchRouter';
 import TrackingRouter from './v1/TrackingRouter';
 import TrackingV3Router from './v3/TrackingRouter';
+import ReportFullnessRouter from './v3/ReportFullnessRouter';
+import GetFullnessRouter from './v3/GetFullnessRouter';
 
 export default {
   AlertsRouter,
@@ -40,4 +42,6 @@ export default {
   SearchRouter,
   TrackingRouter,
   TrackingV3Router,
+  ReportFullnessRouter,
+  GetFullnessRouter,
 };

--- a/src/routers/v3/GetFullnessRouter.js
+++ b/src/routers/v3/GetFullnessRouter.js
@@ -1,5 +1,6 @@
 // @flow
 import ApplicationRouter from '../../appdev/ApplicationRouter';
+import ReliabilityUtils from '../../utils/ReliabilityUtils';
 
 class GetFullnessRouter extends ApplicationRouter<Object> {
   constructor() {
@@ -12,11 +13,20 @@ class GetFullnessRouter extends ApplicationRouter<Object> {
 
   // eslint-disable-next-line require-await
   async content(req): Promise<any> {
-    // const {
-    //   tripId,
-    //   timestamp,
-    //   fullness
-    // } = req.body
+    const {
+      tripId,
+    } = req.body;
+
+    // Validate input
+    if (typeof tripId !== 'number') {
+      return {
+        message: 'Invalid input.',
+      };
+    }
+
+    const recentReport = ReliabilityUtils.getBusFullness(tripId);
+
+    return recentReport;
   }
 }
 

--- a/src/routers/v3/GetFullnessRouter.js
+++ b/src/routers/v3/GetFullnessRouter.js
@@ -1,0 +1,23 @@
+// @flow
+import ApplicationRouter from '../../appdev/ApplicationRouter';
+
+class GetFullnessRouter extends ApplicationRouter<Object> {
+  constructor() {
+    super(['GET']);
+  }
+
+  getPath(): string {
+    return '/getBusFullness/';
+  }
+
+  // eslint-disable-next-line require-await
+  async content(req): Promise<any> {
+    // const {
+    //   tripId,
+    //   timestamp,
+    //   fullness
+    // } = req.body
+  }
+}
+
+export default new GetFullnessRouter().router;

--- a/src/routers/v3/ReportFullnessRouter.js
+++ b/src/routers/v3/ReportFullnessRouter.js
@@ -1,0 +1,34 @@
+// @flow
+import ApplicationRouter from '../../appdev/ApplicationRouter';
+import ReliabilityUtils from '../../utils/ReliabilityUtils';
+
+class ReportFullnessRouter extends ApplicationRouter<Object> {
+  constructor() {
+    super(['POST']);
+  }
+
+  getPath(): string {
+    return '/reportBusFull/';
+  }
+
+  // eslint-disable-next-line require-await
+  async content(req):
+    Promise<any> {
+    // Parse request body
+    const { tripId, time, fullness } = req.body;
+
+    // Validate input
+    if (typeof tripId !== 'number' || typeof time !== 'number' || typeof fullness !== 'number') {
+      return {
+        message: 'Invalid input: tripId, time, and fullness must be numbers',
+      };
+    }
+
+    // Store new report in json file
+    const storeSuccess = await ReliabilityUtils.storeReportJson(tripId, time, fullness);
+
+    return storeSuccess;
+  }
+}
+
+export default new ReportFullnessRouter().router;

--- a/src/routers/v3/ReportFullnessRouter.js
+++ b/src/routers/v3/ReportFullnessRouter.js
@@ -8,7 +8,7 @@ class ReportFullnessRouter extends ApplicationRouter<Object> {
   }
 
   getPath(): string {
-    return '/reportBusFull/';
+    return '/reportBusFullness/';
   }
 
   // eslint-disable-next-line require-await

--- a/src/routers/v3/ReportFullnessRouter.js
+++ b/src/routers/v3/ReportFullnessRouter.js
@@ -25,9 +25,9 @@ class ReportFullnessRouter extends ApplicationRouter<Object> {
     }
 
     // Store new report in json file
-    const storeSuccess = await ReliabilityUtils.storeReportJson(tripId, time, fullness);
+    const storeReport = await ReliabilityUtils.storeReportJson(tripId, time, fullness);
 
-    return storeSuccess;
+    return storeReport;
   }
 }
 

--- a/src/utils/ReliabilityUtils.js
+++ b/src/utils/ReliabilityUtils.js
@@ -1,0 +1,59 @@
+// @flow
+import LogUtils from './LogUtils';
+
+const fs = require('fs');
+
+/**
+ * Stores new fullness report in JSON file.
+ *
+ * @param tripId
+ * @param time
+ * @param fullness
+ * @returns {Object}
+ */
+async function storeReportJson(
+  tripId,
+  time,
+  fullness,
+):
+  Object {
+  const newReport = { tripId, time, fullness };
+
+  const jsonFilePath = './busFullness.json';
+
+  LogUtils.log(jsonFilePath);
+
+  if (fs.existsSync(jsonFilePath)) {
+    // File exists
+    LogUtils.log('File exists!');
+  } else {
+    // File does not exist
+    LogUtils.log('File does not exist.');
+  }
+
+  try {
+    // Read existing reports from JSON file
+    const fileContent = await fs.promises.readFile(jsonFilePath, 'utf-8');
+
+    // Parse data into JSON
+    const jsonData = JSON.parse(fileContent);
+
+    // Add the new report to the reports array
+    jsonData.reports.push(newReport);
+
+    // Write the updated data back to the JSON file
+    await fs.promises.writeFile(jsonFilePath, JSON.stringify(jsonData, null, 2), 'utf-8');
+
+    // Return success response
+    return {
+      report: newReport,
+    };
+  } catch (err) {
+    LogUtils.log({ message: err });
+    return {
+      message: 'Failed to save report',
+    };
+  }
+}
+
+export default { storeReportJson };


### PR DESCRIPTION
## Overview
Implement two routes, `getBusFullness` and `reportBusFullness`. `getBusFullness` return the fullness of a requested trip ID and the minutes elapsed since a fullness was last reported. `reportBusFullness` adds a new report (tripId, time, and fullness) to the database. All data is currently stored in a JSON file called `busFullness.json` at the root of the directory. 

tripId: route number 
time: unix time
fullness: integer value

## Changes Made
`GetFullnessRouter.js`: Implement getBusFullness route
`ReportFullnessRouter.js`: Implement reportBusFullness route
`ReliabilityUtils.js`: Implement helper functions for getBusFullness and reportBusFullness

## Test Coverage
Get bus fullness: 
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/204ef035-a8e4-4bc5-858f-cfe8e817d8f5">

Returns NULL when no reports exist for tripId
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/548bb03a-feb0-462c-8f21-518e071db4a7">

Report bus fullness
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/91d9cdf2-ec62-467c-aab7-3ed99443d81a">
<img width="555" alt="image" src="https://github.com/user-attachments/assets/f2f7a91a-a0e9-4f6e-bdc2-bef15400c8ff">

## Next Steps
Currently fullness is stored as an integer, but we're still waiting on design for what they want reliability to look like and how fullness is measured. The reports are stored in a JSON for now, but we plan to eventually store them in a MongoDB database. 

## Related PRs or Issues